### PR TITLE
Bug time sync

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,22 @@
+# 1.1.0
+
+### New Features
+
+* Add function `.time()` which should be used in time syncing
+* Add function `.syncClocksFull()` which should be used for immediate consecutive time syncs
+* Synced object can be emitted on `synced` event. Check `valid` property for if the sync was done
+* Add detailed description of object returned on `synced` event to README.md
+
+### Breaking Changes
+
+* Changed option named `timeSync` to `sntpTimeSync`
+* Removed function called `.sntpNow()` because it was replaced by `.time()`
+
+### Bug Fixes
+
+* Time sync working
+* Module could not work with local time
+
 # 1.0.1
 
 ### New Features

--- a/openBCIConstants.js
+++ b/openBCIConstants.js
@@ -310,8 +310,11 @@ const OBCIRadioChannelMin   = 0;
 const OBCIRadioPollTimeMax  = 255;
 const OBCIRadioPollTimeMin  = 0;
 
-/** Time sync array size */
-const OBCITimeSyncArraySize = 10;
+/** Time sync stuff */
+const OBCITimeSyncArraySize                 = 10;
+const OBCITimeSyncMultiplierWithSyncConf    = 0.9;
+const OBCITimeSyncMultiplierWithoutSyncConf = 0.75;
+const OBCITimeSyncThresholdTransFailureMS   = 10; //ms
 
 /** Baud Rates */
 const OBCIRadioBaudRateDefault      = 115200;
@@ -845,8 +848,11 @@ module.exports = {
     OBCIRadioChannelMin,
     OBCIRadioPollTimeMax,
     OBCIRadioPollTimeMin,
-    /** Time sync array size */
+    /** Time sync stuff */
     OBCITimeSyncArraySize,
+    OBCITimeSyncMultiplierWithSyncConf,
+    OBCITimeSyncMultiplierWithoutSyncConf,
+    OBCITimeSyncThresholdTransFailureMS,
     /** Baud Rates */
     OBCIRadioBaudRateDefault,
     OBCIRadioBaudRateDefaultStr,

--- a/openBCISample.js
+++ b/openBCISample.js
@@ -521,7 +521,8 @@ var sampleModule = {
     isSuccessInBuffer,
     isTimeSyncSetConfirmationInBuffer,
     makeTailByteFromPacketType,
-    isStopByte
+    isStopByte,
+    newSyncObject
 };
 
 module.exports = sampleModule;
@@ -537,6 +538,20 @@ function newImpedanceObject(channelNumber) {
             raw: -1,
             text: k.OBCIImpedanceTextInit
         }
+    }
+}
+
+function newSyncObject() {
+    return {
+        boardTime: 0,
+        correctedTransmissionTime: false,
+        timeSyncSent: 0,
+        timeSyncSentConfirmation: 0,
+        timeSyncSetPacket: 0,
+        timeRoundTrip: 0,
+        timeTransmission: 0,
+        timeOffset: 0,
+        valid: false
     }
 }
 

--- a/openBCISimulator.js
+++ b/openBCISimulator.js
@@ -190,6 +190,7 @@ function OpenBCISimulatorFactory() {
                 if (this.synced) {
                     if (this.sendSyncSetPacket) {
                         this.sendSyncSetPacket = false;
+                        console.log('sendSyncSetPacket now false');
                         return openBCISample.convertSampleToPacketAccelTimeSyncSet(this.sampleGenerator(sampNumber),now().toFixed(0));
                     } else {
                         return openBCISample.convertSampleToPacketAccelTimeSynced(this.sampleGenerator(sampNumber),now().toFixed(0));
@@ -219,7 +220,9 @@ function OpenBCISimulatorFactory() {
     };
 
     OpenBCISimulator.prototype._syncUp = function() {
-        this.sendSyncSetPacket = true;
+        setTimeout(() => {
+            this.sendSyncSetPacket = true;
+        }, 12); // 3 packets later
     };
 
     OpenBCISimulator.prototype._printEOT = function () {

--- a/openBCISimulator.js
+++ b/openBCISimulator.js
@@ -190,7 +190,6 @@ function OpenBCISimulatorFactory() {
                 if (this.synced) {
                     if (this.sendSyncSetPacket) {
                         this.sendSyncSetPacket = false;
-                        console.log('sendSyncSetPacket now false');
                         return openBCISample.convertSampleToPacketAccelTimeSyncSet(this.sampleGenerator(sampNumber),now().toFixed(0));
                     } else {
                         return openBCISample.convertSampleToPacketAccelTimeSynced(this.sampleGenerator(sampNumber),now().toFixed(0));

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci",
-  "version": "1.0.1",
+  "version": "1.1.0",
   "description": "The official Node.js SDK for the OpenBCI Biosensor Board.",
   "main": "openBCIBoard",
   "scripts": {
@@ -17,7 +17,6 @@
   "dependencies": {
     "buffer-equal": "^1.0.0",
     "gaussian": "^1.0.0",
-    "istanbul": "^0.4.2",
     "mathjs": "^3.3.0",
     "performance-now": "^0.2.0",
     "serialport": "3.1.2",
@@ -28,10 +27,10 @@
     "test": "test"
   },
   "devDependencies": {
-    "buffer-equal": "^1.0.0",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.2.0",
     "codecov": "^1.0.1",
+    "istanbul": "^0.4.4",
     "mocha": "^2.3.4",
     "sandboxed-module": "^2.0.3",
     "sinon": "^1.17.2",

--- a/test/OpenBCIConstants-test.js
+++ b/test/OpenBCIConstants-test.js
@@ -291,6 +291,20 @@ describe('OpenBCIConstants', function() {
             assert.equal('1', k.OBCIChannelImpedanceTestSignalApplied);
         });
     });
+    describe('Time Sync Stuff',function() {
+        it('Can get proper array size',function() {
+            assert.equal(10, k.OBCITimeSyncArraySize);
+        });
+        it('Get correct time sync with conf',function() {
+            assert.equal(0.9, k.OBCITimeSyncMultiplierWithSyncConf);
+        });
+        it('Get correct time sync without conf',function() {
+            assert.equal(0.75, k.OBCITimeSyncMultiplierWithoutSyncConf);
+        });
+        it('Get correct time sync transmission threshold',function() {
+            assert.equal(10, k.OBCITimeSyncThresholdTransFailureMS);
+        });
+    });
     describe('SD card Commands',function() {
         it('logs for 1 hour', function() {
             assert.equal('G', k.OBCISDLogForHour1);

--- a/test/OpenBCIConstants-test.js
+++ b/test/OpenBCIConstants-test.js
@@ -667,78 +667,78 @@ describe('OpenBCIConstants', function() {
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 2', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = '@';
+            var result = k.commandChannelOn(2);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 3', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = '#';
+            var result = k.commandChannelOn(3);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 4', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = '$';
+            var result = k.commandChannelOn(4);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 5', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = '%';
+            var result = k.commandChannelOn(5);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 6', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = '^';
+            var result = k.commandChannelOn(6);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 7', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = '&';
+            var result = k.commandChannelOn(7);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 8', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = '*';
+            var result = k.commandChannelOn(8);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 9', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = 'Q';
+            var result = k.commandChannelOn(9);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 10', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = 'W';
+            var result = k.commandChannelOn(10);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 11', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = 'E';
+            var result = k.commandChannelOn(11);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 12', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = 'R';
+            var result = k.commandChannelOn(12);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 13', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = 'T';
+            var result = k.commandChannelOn(13);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 14', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = 'Y';
+            var result = k.commandChannelOn(14);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 15', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = 'U';
+            var result = k.commandChannelOn(15);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Channel 16', function() {
-            var expectation = '!';
-            var result = k.commandChannelOn(1);
+            var expectation = 'I';
+            var result = k.commandChannelOn(16);
             return expect(result).to.eventually.equal(expectation);
         });
         it('Invalid channel request', function() {

--- a/test/OpenBCISample-test.js
+++ b/test/OpenBCISample-test.js
@@ -1344,7 +1344,38 @@ describe('openBCISample',function() {
             expect(openBCISample.makeTailByteFromPacketType(-2)).to.equal(0xC0);
         });
     });
+    describe('#newSyncObject',function() {
+        var syncObj = openBCISample.newSyncObject();
+        it("should have property timeSyncSent",function() {
+            expect(syncObj).to.have.property("timeSyncSent",0);
+        });
+        it("should have property timeOffset",function() {
+            expect(syncObj).to.have.property("timeOffset",0);
+        });
+        it("should have property timeRoundTrip",function() {
+            expect(syncObj).to.have.property("timeRoundTrip",0);
+        });
+        it("should have property timeTransmission",function() {
+            expect(syncObj).to.have.property("timeTransmission",0);
+        });
+        it("should have property timeSyncSentConfirmation",function() {
+            expect(syncObj).to.have.property("timeSyncSentConfirmation",0);
+        });
+        it("should have property timeSyncSetPacket",function() {
+            expect(syncObj).to.have.property("timeSyncSetPacket",0);
+        });
+        it("should have property valid",function() {
+            expect(syncObj).to.have.property("valid",false);
+        });
+        it("should have property correctedTransmissionTime",function() {
+            expect(syncObj).to.have.property("correctedTransmissionTime",false);
+        });
+        it("should have property boardTime",function() {
+            expect(syncObj).to.have.property("boardTime",0);
+        });
+    })
 });
+
 
 describe('#goertzelProcessSample', function() {
     var numberOfChannels = k.OBCINumberOfChannelsDefault;

--- a/test/openBCIBoard-test.js
+++ b/test/openBCIBoard-test.js
@@ -77,7 +77,8 @@ describe('openbci-sdk',function() {
             expect(board.options.simulatorInjectLineNoise).to.equal(k.OBCISimulatorLineNoiseHz60);
             expect(board.options.simulatorSampleRate).to.equal(k.OBCISampleRate250);
             expect(board.options.simulatorSerialPortFailure).to.be.false;
-            expect(board.options.timeSync).to.be.false;
+            expect(board.options.sntpTimeSync).to.be.false;
+            expect(board.options.sntpTimeSyncHost).to.equal('pool.ntp.org');
             expect(board.options.verbose).to.be.false;
             expect(board.sampleRate()).to.equal(250);
             expect(board.numberOfChannels()).to.equal(8);
@@ -241,14 +242,38 @@ describe('openbci-sdk',function() {
         });
         it('should be able to enter sync mode', function() {
             var ourBoard1 = new openBCIBoard.OpenBCIBoard({
-                timeSync: true
+                sntpTimeSync: true
             });
-            expect(ourBoard1.options.timeSync).to.be.true;
+            expect(ourBoard1.options.sntpTimeSync).to.be.true;
             // Verify multi case support
             var ourBoard2 = new openBCIBoard.OpenBCIBoard({
-                timesync: true
+                sntptimesync: true
             });
-            expect(ourBoard2.options.timeSync).to.be.true;
+            expect(ourBoard2.options.sntpTimeSync).to.be.true;
+        });
+        it('should be able to change the ntp pool host', function() {
+            var expectedPoolName = 'time.apple.com';
+            var ourBoard1 = new openBCIBoard.OpenBCIBoard({
+                sntpTimeSyncHost: expectedPoolName
+            });
+            expect(ourBoard1.options.sntpTimeSyncHost).to.equal(expectedPoolName);
+            // Verify multi case support
+            var ourBoard2 = new openBCIBoard.OpenBCIBoard({
+                sntptimesynchost: expectedPoolName
+            });
+            expect(ourBoard2.options.sntpTimeSyncHost).to.equal(expectedPoolName);
+        });
+        it('should be able to change the ntp pool port', function() {
+            var expectedPortNumber = 73;
+            var ourBoard1 = new openBCIBoard.OpenBCIBoard({
+                sntpTimeSyncPort: expectedPortNumber
+            });
+            expect(ourBoard1.options.sntpTimeSyncPort).to.equal(expectedPortNumber);
+            // Verify multi case support
+            var ourBoard2 = new openBCIBoard.OpenBCIBoard({
+                sntptimesyncport: expectedPortNumber
+            });
+            expect(ourBoard2.options.sntpTimeSyncPort).to.equal(expectedPortNumber);
         });
         it('can enter verbose mode', function() {
             ourBoard = new openBCIBoard.OpenBCIBoard({
@@ -889,6 +914,8 @@ describe('openbci-sdk',function() {
             funcSpyTimeSyncSet.reset();
             funcSpyTimeSyncedAccel.reset();
             funcSpyTimeSyncedRawAux.reset();
+
+            ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
         });
         after(function() {
             // ourBoard = null;
@@ -988,6 +1015,261 @@ describe('openbci-sdk',function() {
         });
     });
 
+    describe("#_processPacketTimeSyncSet", function() {
+        var timeSyncSetPacket;
+        var ourBoard;
+        before(() => {
+            ourBoard = new openBCIBoard.OpenBCIBoard({
+                verbose: false
+            });
+
+        });
+        beforeEach(() => {
+            timeSyncSetPacket = openBCISample.samplePacketRawAuxTimeSyncSet();
+            ourBoard.sync.timeOffsetArray = [];
+        });
+        afterEach(() => {
+            ourBoard.sync.curSyncObj = null;
+        });
+        it("should reject if no sync in progress", function(done) {
+            var timeSetPacketArrived = ourBoard.time();
+            ourBoard.curParsingMode = k.OBCIParsingTimeSyncSent;
+            ourBoard._processPacketTimeSyncSet(timeSyncSetPacket,timeSetPacketArrived).should.be.rejected.and.notify(done);
+        });
+        it("should reject if no sent confimation found", function(done) {
+            var timeSetPacketArrived = ourBoard.time();
+            ourBoard.curParsingMode = k.OBCIParsingTimeSyncSent;
+            ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
+            ourBoard._processPacketTimeSyncSet(timeSyncSetPacket,timeSetPacketArrived).should.be.rejected.and.notify(done);
+        });
+        it("should reset global sync variables if no sent confimation found", function(done) {
+            var timeSetPacketArrived = ourBoard.time();
+            ourBoard.curParsingMode = k.OBCIParsingTimeSyncSent;
+            ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
+            ourBoard._processPacketTimeSyncSet(timeSyncSetPacket,timeSetPacketArrived)
+                .then(() => {
+                    done("failed to get rejected");
+                })
+                .catch(function(err) {
+                    expect(ourBoard.curParsingMode).to.equal(k.OBCIParsingNormal);
+                    expect(ourBoard.sync.curSyncObj).to.be.null;
+                    done();
+                });
+        });
+        it("should emit sycned event with valid false", function(done) {
+            var timeSetPacketArrived = ourBoard.time();
+            ourBoard.curParsingMode = k.OBCIParsingTimeSyncSent;
+            ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
+            ourBoard.once('synced',obj => {
+                expect(obj.valid).to.be.false;
+                done();
+            })
+            ourBoard._processPacketTimeSyncSet(timeSyncSetPacket,timeSetPacketArrived);
+        });
+        it("should calculate round trip time as the difference between time sent and time set packet arrived",function(done) {
+            var timeSetPacketArrived = ourBoard.time();
+            var expectedRoundTripTime = 20; //ms
+            ourBoard.curParsingMode = k.OBCIParsingNormal; // indicates the sent conf was found
+            // Make a new object!
+            ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
+            // Set the sent time
+            ourBoard.sync.curSyncObj.timeSyncSent = timeSetPacketArrived - expectedRoundTripTime;
+
+            ourBoard.once('synced',obj => {
+                expect(obj.timeRoundTrip).to.equal(expectedRoundTripTime);
+                done();
+            })
+            ourBoard._processPacketTimeSyncSet(timeSyncSetPacket,timeSetPacketArrived);
+        });
+        it("should calculate transmission time as the difference between round trip time and (sentConf - sent) when set arrived - sent conf is larger than threshold",function(done) {
+            var timeSetPacketArrived = ourBoard.time();
+            var expectedRoundTripTime = 20; //ms
+            var expectedTimeTillSentConf = expectedRoundTripTime - k.OBCITimeSyncThresholdTransFailureMS - 1; // 9 ms
+            // Setup
+            ourBoard.curParsingMode = k.OBCIParsingNormal; // indicates the sent conf was found
+            // Make a new object!
+            ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
+            // Set the sent time
+            ourBoard.sync.curSyncObj.timeSyncSent = timeSetPacketArrived - expectedRoundTripTime;
+            ourBoard.sync.curSyncObj.timeSyncSentConfirmation = ourBoard.sync.curSyncObj.timeSyncSent + expectedTimeTillSentConf;
+
+            ourBoard.once('synced',obj => {
+                expect(obj.timeTransmission).to.equal(obj.timeRoundTrip - (obj.timeSyncSentConfirmation - obj.timeSyncSent));
+                done();
+            })
+            ourBoard._processPacketTimeSyncSet(timeSyncSetPacket,timeSetPacketArrived);
+        });
+        it("should calculate transmission time as a percentage of round trip time when set arrived - sent conf is smaller than threshold",function(done) {
+            var timeSetPacketArrived = ourBoard.time();
+            var expectedRoundTripTime = 20; //ms
+            var expectedTimeTillSentConf = expectedRoundTripTime - k.OBCITimeSyncThresholdTransFailureMS + 1; // 11 ms
+            // Setup
+            ourBoard.curParsingMode = k.OBCIParsingNormal; // indicates the sent conf was found
+            // Make a new object!
+            ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
+            // Set the sent time
+            ourBoard.sync.curSyncObj.timeSyncSent = timeSetPacketArrived - expectedRoundTripTime;
+            ourBoard.sync.curSyncObj.timeSyncSentConfirmation = ourBoard.sync.curSyncObj.timeSyncSent + expectedTimeTillSentConf;
+
+            ourBoard.once('synced',obj => {
+                expect(obj.timeTransmission).to.equal(obj.timeRoundTrip * k.OBCITimeSyncMultiplierWithSyncConf);
+                done();
+            })
+            ourBoard._processPacketTimeSyncSet(timeSyncSetPacket,timeSetPacketArrived);
+        });
+        it("should calculate offset time as a time packet arrived - transmission time - board time",function(done) {
+            var timeSetPacketArrived = ourBoard.time();
+            var expectedRoundTripTime = 20; //ms
+            var expectedTimeTillSentConf = expectedRoundTripTime - k.OBCITimeSyncThresholdTransFailureMS - 2; // 8 ms
+            // Set the board time
+            var boardTime = 5000;
+            timeSyncSetPacket.writeInt32BE(boardTime,k.OBCIPacketPositionTimeSyncTimeStart);
+
+            // Setup
+            ourBoard.curParsingMode = k.OBCIParsingNormal; // indicates the sent conf was found
+            // Make a new object!
+            ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
+            // Set the sent time
+            ourBoard.sync.curSyncObj.timeSyncSent = timeSetPacketArrived - expectedRoundTripTime;
+            ourBoard.sync.curSyncObj.timeSyncSentConfirmation = ourBoard.sync.curSyncObj.timeSyncSent + expectedTimeTillSentConf;
+
+            var expectedTransmissionTime = expectedRoundTripTime - (ourBoard.sync.curSyncObj.timeSyncSentConfirmation - ourBoard.sync.curSyncObj.timeSyncSent);
+
+            var expectedTimeOffset = timeSetPacketArrived - expectedTransmissionTime - boardTime;
+
+            ourBoard.once('synced',obj => {
+                expect(obj.timeOffset,"object timeOffset").to.equal(expectedTimeOffset);
+                expect(ourBoard.sync.timeOffsetMaster,"master time offset").to.equal(expectedTimeOffset);
+                done();
+            })
+            ourBoard._processPacketTimeSyncSet(timeSyncSetPacket,timeSetPacketArrived);
+        });
+        it("should calculate offset time as an average of previous offset times",function(done) {
+            var timeSetPacketArrived = ourBoard.time();
+            var expectedRoundTripTime = 20; //ms
+            var expectedTimeTillSentConf = expectedRoundTripTime - k.OBCITimeSyncThresholdTransFailureMS - 2; // 8 ms
+            // Set the board time
+            var boardTime = 5000;
+            timeSyncSetPacket.writeInt32BE(boardTime,k.OBCIPacketPositionTimeSyncTimeStart);
+
+            // Setup
+            ourBoard.curParsingMode = k.OBCIParsingNormal; // indicates the sent conf was found
+            // Make a new object!
+            ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
+            // Set the sent time
+            ourBoard.sync.curSyncObj.timeSyncSent = timeSetPacketArrived - expectedRoundTripTime;
+            ourBoard.sync.curSyncObj.timeSyncSentConfirmation = ourBoard.sync.curSyncObj.timeSyncSent + expectedTimeTillSentConf;
+
+            var expectedTransmissionTime = expectedRoundTripTime - (ourBoard.sync.curSyncObj.timeSyncSentConfirmation - ourBoard.sync.curSyncObj.timeSyncSent);
+
+            var expectedTimeOffset = timeSetPacketArrived - expectedTransmissionTime - boardTime;
+
+            var dif1 = 3;
+            ourBoard.sync.timeOffsetArray.push(expectedTimeOffset + dif1);
+            var dif2 = 1;
+            ourBoard.sync.timeOffsetArray.push(expectedTimeOffset + dif2);
+
+            ourBoard.once('synced',obj => {
+                expect(obj.timeOffset,"object timeOffset").to.equal(expectedTimeOffset);
+
+                var expectedMasterTimeoffset = math.floor((obj.timeOffset + (obj.timeOffset + dif1) + (obj.timeOffset + dif2)) / 3);
+                expect(ourBoard.sync.timeOffsetMaster,"master time offset").to.equal(expectedMasterTimeoffset);
+                done();
+            })
+            ourBoard._processPacketTimeSyncSet(timeSyncSetPacket,timeSetPacketArrived);
+        });
+    });
+
+    describe("#time", function() {
+        it("should use sntp time when sntpTimeSync specified in options", function() {
+            var ourBoard = new openBCIBoard.OpenBCIBoard({
+                verbose: true,
+                sntpTimeSync: true
+            });
+            var funcSpySntpNow = sinon.spy(ourBoard,"_sntpNow");
+
+            ourBoard.time();
+
+            funcSpySntpNow.should.have.been.calledOnce;
+
+            funcSpySntpNow.reset();
+
+            funcSpySntpNow = null;
+        });
+        it("should use Date.now() for time when sntpTimeSync is not specified in options", function() {
+            var ourBoard = new openBCIBoard.OpenBCIBoard({
+                verbose: true
+            });
+            var funcSpySntpNow = sinon.spy(ourBoard,"_sntpNow");
+
+            ourBoard.time();
+
+            funcSpySntpNow.should.not.have.been.called;
+
+            funcSpySntpNow.reset();
+
+            funcSpySntpNow = null;
+        });
+        it("should emit sntpTimeLock event after sycned with ntp server", function(done) {
+            var ourBoard = new openBCIBoard.OpenBCIBoard({
+                verbose: true,
+                sntpTimeSync: true
+            });
+
+            ourBoard.once('sntpTimeLock', () => {
+                done();
+            })
+        });
+    });
+    describe("#sntpStart",function() {
+        var ourBoard;
+        before(() => {
+            ourBoard = new openBCIBoard.OpenBCIBoard();
+            ourBoard.sntpStop();
+        });
+        after(() => {
+            ourBoard.sntpStop();
+        })
+        it("should be able to start ntp server", done => {
+            expect(ourBoard.sntp.isLive()).to.be.false;
+            ourBoard.sntpStart()
+                .then(() => {
+                    expect(ourBoard.sntp.isLive()).to.be.true;
+                })
+            ourBoard.once("sntpTimeLock", () => {
+                done();
+            });
+        });
+    });
+    describe("#sntpStop",function() {
+        var ourBoard;
+        before(done => {
+            ourBoard = new openBCIBoard.OpenBCIBoard({
+                sntpTimeSync: true
+            });
+            ourBoard.once("sntpTimeLock", () => {
+                done();
+            });
+        });
+        after(() => {
+            ourBoard.sntpStop();
+        })
+        it("should be able to stop the ntp server and set the globals correctly",function() {
+            // Verify the before condition is correct
+            expect(ourBoard.options.sntpTimeSync).to.be.true;
+            expect(ourBoard.sync.sntpActive).to.be.true;
+            expect(ourBoard.sntp.isLive()).to.be.true;
+
+            // Call the function under test
+            ourBoard.sntpStop();
+
+            // Ensure the globals were set off
+            expect(ourBoard.options.sntpTimeSync).to.be.false;
+            expect(ourBoard.sync.sntpActive).to.be.false;
+            expect(ourBoard.sntp.isLive()).to.be.false;
+
+        });
+    });
     describe("#_processParseBufferForReset",function() {
         var ourBoard;
 
@@ -1062,6 +1344,9 @@ describe('openbci-sdk',function() {
                 verbose: true
             });
         });
+        beforeEach(() => {
+            ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
+        })
         afterEach(() => {
             ourBoard.buffer = null;
         });
@@ -1112,6 +1397,7 @@ describe('openbci-sdk',function() {
             });
             beforeEach(() => {
                 ourBoard.curParsingMode = k.OBCIParsingTimeSyncSent;
+                ourBoard.sync.curSyncObj = openBCISample.newSyncObject();
                 // spy.reset();
             });
             it("should call to find the time sync set character in the buffer", function(done) {
@@ -1174,8 +1460,6 @@ describe('openbci-sdk',function() {
 
                 var sampleCounter = 0;
 
-                ourBoard.sync.timeSent = 0;
-
                 var newSample = sample => {
                     // console.log(`sample ${JSON.stringify(sample)}`);
                     if (sampleCounter == 0) {
@@ -1185,8 +1469,7 @@ describe('openbci-sdk',function() {
                         // bufferEqual(buf1, buffer).should.be.true;
                         // ourBoard.buffer.length.should.equal(buf1.length);
                         ourBoard.removeListener("sample", newSample);
-                        ourBoard.curParsingMode.should.equal(k.OBCIParsingNormal);
-                        ourBoard.sync.timeGotPacketSent.should.be.greaterThan(0);
+                        expect(ourBoard.curParsingMode).to.equal(k.OBCIParsingNormal);
                         done();
                     }
                     sampleCounter++;
@@ -2382,10 +2665,13 @@ describe('openbci-sdk',function() {
 
     describe('#hardwareValidation', function() {
         this.timeout(20000); // long timeout for pleanty of stream time :)
-        var runHardwareValidation = masterPortName !== k.OBCISimulatorPortName;
+        var runHardwareValidation = true;
         var wstream;
         var board;
         before(function(done) {
+            if (masterPortName === k.OBCISimulatorPortName) {
+                runHardwareValidation = false;
+            }
             if (runHardwareValidation) {
                 board = new openBCIBoard.OpenBCIBoard({
                     verbose:true
@@ -2546,7 +2832,6 @@ describe('#daisy', function () {
     });
 });
 
-// Need a better test
 describe('#sync', function() {
     var ourBoard;
     this.timeout(4000);
@@ -2649,9 +2934,10 @@ describe('#sync', function() {
         // });
         it('can sync while streaming', done => {
             var syncAfterSamples = 50;
-
+            var notSynced = true;
             var samp = sample => {
-                if (sample.sampleNumber >= syncAfterSamples) {
+                if (sample.sampleNumber >= syncAfterSamples && notSynced) {
+                    notSynced = false;
                     // Call the first one
                     ourBoard.syncClocks().catch(err => done);
                 }
@@ -2659,7 +2945,8 @@ describe('#sync', function() {
             ourBoard.on('sample',samp);
             ourBoard.streamStart().catch(err => done);
             // Attached the emitted
-            ourBoard.once('synced',() => {
+            ourBoard.once('synced',obj => {
+                console.log('syhnc obj', obj);
                 ourBoard.disconnect()
                     .then(() => {
                         done();

--- a/test/openBCISimulator-test.js
+++ b/test/openBCISimulator-test.js
@@ -638,21 +638,26 @@ describe('openBCISimulator',function() {
         it("should emit a time sync set packet followed by a time synced accel packet after sync up call", function(done) {
             simulator.synced = false;
             var emitCounter = 0;
+            var maxPacketsBetweenSetPacket = 5;
             var newData = data => {
                 if (emitCounter === 0) { // the time sync packet is emitted here
                     // Make a call to start streaming
                     simulator.write(k.OBCIStreamStart, err => {
                         if (err) done(err);
                     });
-                } else if (emitCounter === 1) {
-                    expect(openBCISample.getRawPacketType(data[k.OBCIPacketPositionStopByte])).to.equal(k.OBCIStreamPacketAccelTimeSyncSet);
-                } else if (emitCounter === 2) {
-                    expect(openBCISample.getRawPacketType(data[k.OBCIPacketPositionStopByte])).to.equal(k.OBCIStreamPacketAccelTimeSynced);
-                    simulator.write(k.OBCIStreamStop, err => {
-                        if (err) done(err);
+                } else if (emitCounter < maxPacketsBetweenSetPacket) {
+                    if (openBCISample.getRawPacketType(data[k.OBCIPacketPositionStopByte]) === k.OBCIStreamPacketAccelTimeSyncSet) {
                         simulator.removeListener('data', newData);
-                        done();
-                    });
+                        simulator.write(k.OBCIStreamStop, err => {
+                            if (err) done(err);
+                            done();
+                        });
+                    } else {
+                        expect(openBCISample.getRawPacketType(data[k.OBCIPacketPositionStopByte])).to.equal(k.OBCIStreamPacketAccelTimeSynced);
+
+                    }
+                } else {
+                    done("Failed to get set packet in time")
                 }
                 emitCounter++;
             };
@@ -669,22 +674,27 @@ describe('openBCISimulator',function() {
             simulator.synced = false;
             simulator.options.accel = false;
             var emitCounter = 0;
+            var maxPacketsBetweenSetPacket = 5;
             var newData = data => {
                 if (emitCounter === 0) { // the time sync packet is emitted here
                     // Make a call to start streaming
                     simulator.write(k.OBCIStreamStart, err => {
                         if (err) done(err);
                     });
-                } else if (emitCounter === 1) {
-                    expect(openBCISample.getRawPacketType(data[k.OBCIPacketPositionStopByte])).to.equal(k.OBCIStreamPacketRawAuxTimeSyncSet);
-                } else if (emitCounter === 2) {
-                    expect(openBCISample.getRawPacketType(data[k.OBCIPacketPositionStopByte])).to.equal(k.OBCIStreamPacketRawAuxTimeSynced);
-                    simulator.write(k.OBCIStreamStop, err => {
-                        if (err) done(err);
+                } else if (emitCounter < maxPacketsBetweenSetPacket) {
+                    if (openBCISample.getRawPacketType(data[k.OBCIPacketPositionStopByte]) === k.OBCIStreamPacketRawAuxTimeSyncSet) {
                         simulator.removeListener('data', newData);
-                        done();
-                    });
+                        simulator.write(k.OBCIStreamStop, err => {
+                            if (err) done(err);
+                            done();
+                        });
+                    } else {
+                        expect(openBCISample.getRawPacketType(data[k.OBCIPacketPositionStopByte])).to.equal(k.OBCIStreamPacketRawAuxTimeSynced);
+                    }
+                } else {
+                    done("Failed to get set packet in time")
                 }
+
                 emitCounter++;
             };
 


### PR DESCRIPTION
# 1.1.0

### New Features

* Add function `.time()` which should be used in time syncing
* Add function `.syncClocksFull()` which should be used for immediate consecutive time syncs
* Synced object can be emitted on `synced` event. Check `valid` property for if the sync was done
* Add detailed description of object returned on `synced` event to README.md

### Breaking Changes

* Changed option named `timeSync` to `sntpTimeSync`
* Removed function called `.sntpNow()` because it was replaced by `.time()`

### Bug Fixes

* Time sync working
* Module could not work with local time