### PR TITLE
Fix constants not set in constructor

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 1.3.1
+
+### Bug Fixes
+
+* Fixed bug where `connected` and `streaming` were not set in constructor
+
 # 1.3.0
 
 ### New Features

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -145,6 +145,9 @@ function OpenBCIFactory() {
         this.accelArray = [0,0,0]; // X, Y, Z
         this.channelSettingsArray = k.channelSettingsArrayInit(k.numberOfChannelsForBoardType(this.options.boardType));
         this.writeOutArray = new Array(100);
+        // Booleans
+        this.connected = false;
+        this.streaming = false;
         // Buffers
         this.buffer = null;
         this.masterBuffer = masterBufferMaker();

--- a/test/openBCIBoard-test.js
+++ b/test/openBCIBoard-test.js
@@ -82,6 +82,8 @@ describe('openbci-sdk',function() {
             expect(board.options.verbose).to.be.false;
             expect(board.sampleRate()).to.equal(250);
             expect(board.numberOfChannels()).to.equal(8);
+            expect(board.connected).to.be.false;
+            expect(board.streaming).to.be.false;
         });
         it('should be able to set ganglion mode', () => {
             var board = new openBCIBoard.OpenBCIBoard({


### PR DESCRIPTION
# 1.3.1

### Bug Fixes

* Fixed bug where `connected` and `streaming` were not set in constructor