### PR TITLE
 Simulate packet fragmentation; fixes #100

### DIFF
--- a/README.md
+++ b/README.md
@@ -389,6 +389,10 @@ Board optional configurations.
 * `simulatorFirmwareVersion` {String} - Allows the simulator to use firmware version 2 features. (2 Possible Options)
   * `v1` - Firmware Version 1 (Default)
   * `v2` - Firmware Version 2
+* `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation. (3 Possible Options)
+  * `Random` - output randomly-lengthed chunks of data (Default)
+  * `OneByOne` - output each byte separately
+  * `None` - do not fragment packets; output complete chunks immediately after they are produced
 * `simulatorHasAccelerometer` - {Boolean} - Sets simulator to send packets with accelerometer data. (Default `true`)
 * `simulatorInjectAlpha` - {Boolean} - Inject a 10Hz alpha wave in Channels 1 and 2 (Default `true`)
 * `simulatorInjectLineNoise` {String} - Injects line noise on channels. (3 Possible Options)

--- a/README.md
+++ b/README.md
@@ -389,13 +389,13 @@ Board optional configurations.
 * `simulatorFirmwareVersion` {String} - Allows the simulator to use firmware version 2 features. (2 Possible Options)
   * `v1` - Firmware Version 1 (Default)
   * `v2` - Firmware Version 2
-* `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation. (4 Possible Options)
-  * `random` - output random small chunks of data interspersed with full buffers (Default)
+* `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation, which occurs commonly in real devices.  It is recommended to test code with this enabled.  (4 Possible Options)
+  * `none` - do not fragment packets; output complete chunks immediately when produced (Default)
+  * `random` - output random small chunks of data interspersed with full buffers
   * `fullBuffers` - allow buffers to fill up until latency timer has expired
   * `oneByOne` - output each byte separately
-  * `none` - do not fragment packets; output complete chunks immediately after they are produced
-* `simulatorLatencyTime` {Number} - The time in milliseconds to wait before sending partially full buffers of data.  (Default `16`)
-* `simulatorBufferSize` {Number} - The size of a full buffer of data. (Default `4096`)
+* `simulatorLatencyTime` {Number} - The time in milliseconds to wait before sending partially full buffers of data, if `simulatorFragmentation` is specified.  (Default `16`)
+* `simulatorBufferSize` {Number} - The size of a full buffer of data, if `simulatorFragmentation` is specified. (Default `4096`)
 * `simulatorHasAccelerometer` - {Boolean} - Sets simulator to send packets with accelerometer data. (Default `true`)
 * `simulatorInjectAlpha` - {Boolean} - Inject a 10Hz alpha wave in Channels 1 and 2 (Default `true`)
 * `simulatorInjectLineNoise` {String} - Injects line noise on channels. (3 Possible Options)

--- a/README.md
+++ b/README.md
@@ -389,16 +389,19 @@ Board optional configurations.
 * `simulatorFirmwareVersion` {String} - Allows the simulator to use firmware version 2 features. (2 Possible Options)
   * `v1` - Firmware Version 1 (Default)
   * `v2` - Firmware Version 2
-* `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation. (3 Possible Options)
-  * `Random` - output randomly-lengthed chunks of data (Default)
-  * `OneByOne` - output each byte separately
-  * `None` - do not fragment packets; output complete chunks immediately after they are produced
+* `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation. (4 Possible Options)
+  * `random` - output random small chunks of data interspersed with full buffers (Default)
+  * `fullBuffers` - allow buffers to fill up until latency timer has expired
+  * `oneByOne` - output each byte separately
+  * `none` - do not fragment packets; output complete chunks immediately after they are produced
+* `simulatorLatencyTime` {Number} - The time in milliseconds to wait before sending partially full buffers of data.  (Default `16`)
+* `simulatorBufferSize` {Number} - The size of a full buffer of data. (Default `4096`)
 * `simulatorHasAccelerometer` - {Boolean} - Sets simulator to send packets with accelerometer data. (Default `true`)
 * `simulatorInjectAlpha` - {Boolean} - Inject a 10Hz alpha wave in Channels 1 and 2 (Default `true`)
 * `simulatorInjectLineNoise` {String} - Injects line noise on channels. (3 Possible Options)
   * `60Hz` - 60Hz line noise (Default) [America]
   * `50Hz` - 50Hz line noise [Europe]
-  * `None` - Do not inject line noise.
+  * `none` - Do not inject line noise.
 * `simulatorSampleRate` {Number} - The sample rate to use for the simulator. Simulator will set to 125 if `simulatorDaisyModuleAttached` is set `true`. However, setting this option overrides that setting and this sample rate will be used. (Default is `250`)
 * `simulatorSerialPortFailure` {Boolean} - Simulates not being able to open a serial connection. Most likely due to a OpenBCI dongle not being plugged in.
 * `sntpTimeSync` - {Boolean} Syncs the module up with an SNTP time server and uses that as single source of truth instead of local computer time. If you are running experiments on your local computer, keep this `false`. (Default `false`)

--- a/changelog.md
+++ b/changelog.md
@@ -13,6 +13,10 @@
 
 * The setting for simulatorInjectLineNoise has changed from `None` to `none`
 
+### Bug Fixes
+
+* Don't drop early packet fragments after board reset
+
 # 1.3.3
 
 ### New Features

--- a/changelog.md
+++ b/changelog.md
@@ -15,7 +15,8 @@
 
 ### Bug Fixes
 
-* Don't drop early packet fragments after board reset
+* Fixed bug where early packet fragments were dropped after board reset
+* Fixed bug where time sync replies that began a buffered chunk were ignored
 
 # 1.3.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,8 +1,16 @@
 # 1.4.0
 
+### New Features
+
+* Now simulates configurable packet fragmentation, buffer size, and latency timer
+
 ### Enhancements
 
 * Implement and adapt semi-standard code style. Closes #83
+
+### Breaking Changes
+
+* The setting for simulatorInjectLineNoise has changed from `None` to `none`
 
 # 1.3.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -7,6 +7,7 @@
 ### Enhancements
 
 * Implement and adapt semi-standard code style. Closes #83
+* autoFindOpenBCIBoard now notices and uses the stock dongle on Linux
 
 ### Breaking Changes
 

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -25,7 +25,7 @@ function OpenBCIFactory () {
     simulatorBoardFailure: false,
     simulatorDaisyModuleAttached: false,
     simulatorFirmwareVersion: k.OBCIFirmwareV1,
-    simulatorFragmentation: 'random',
+    simulatorFragmentation: k.OBCISimulatorFragmentationNone,
     simulatorLatencyTime: 16,
     simulatorBufferSize: 4096,
     simulatorHasAccelerometer: true,
@@ -69,17 +69,19 @@ function OpenBCIFactory () {
   *              `v1` - Firmware Version 1 (Default)
   *              `v2` - Firmware Version 2
   *
-  *     - `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation.
+  *     - `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation, which
+  *                  occurs commonly in real devices.  It is recommended to test code with this enabled.
   *          4 Possible Options:
-  *              `random` - output random small chunks of data interspersed with full buffers (Default)
+  *              `none` - do not fragment packets; output complete chunks immediately when produced (Default)
+  *              `random` - output random small chunks of data interspersed with full buffers
   *              `fullBuffers` - allow buffers to fill up until the latency timer has expired
   *              `oneByOne` - output each byte separately
-  *              `none` - do not fragment packets; output complete chunks immediately after they are produced
   *
-  *     - `simulatorLatencyTime` {Number} - The time in milliseconds to wait before sending partially full buffers.
-  *                  (Default `16`)
+  *     - `simulatorLatencyTime` {Number} - The time in milliseconds to wait before sending partially full buffers,
+                     if `simulatorFragmentation` is specified. (Default `16`)
   *
-  *     - `simulatorBufferSize` {Number} - The size of a full buffer of data. (Default `4096`)
+  *     - `simulatorBufferSize` {Number} - The size of a full buffer of data, if `simulatorFragmentation` is
+  *                  specified. (Default `4096`)
   *
   *     - `simulatorHasAccelerometer` - {Boolean} - Sets simulator to send packets with accelerometer data. (Default `true`)
   *

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -131,6 +131,8 @@ function OpenBCIFactory () {
     if (opts.simulatorFragmentation !== 'random' && opts.simulatorFragmentation !== 'fullBuffers' && opts.simulatorFragmentation !== 'oneByOne' && opts.simulatorFragmentation !== 'none') {
       opts.simulatorFragmentation = 'random';
     }
+    opts.simulatorLatencyTime = options.simulatorLatencyTime || options.simulatorlatencytime || _options.simulatorLatencyTime;
+    opts.simulatorBufferSize = options.simulatorBufferSize || options.simulatorbuffersize || _options.simulatorBufferSize;
     if (options.simulatorHasAccelerometer === false || options.simulatorhasaccelerometer === false) {
       opts.simulatorHasAccelerometer = false;
     } else {

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -25,6 +25,7 @@ function OpenBCIFactory () {
     simulatorBoardFailure: false,
     simulatorDaisyModuleAttached: false,
     simulatorFirmwareVersion: k.OBCIFirmwareV1,
+    simulatorFragmentation: 'Random',
     simulatorHasAccelerometer: true,
     simulatorInternalClockDrift: 0,
     simulatorInjectAlpha: true,
@@ -65,6 +66,12 @@ function OpenBCIFactory () {
   *          2 Possible Options:
   *              `v1` - Firmware Version 1 (Default)
   *              `v2` - Firmware Version 2
+  *
+  *     - `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation.
+  *          3 Possible Options:
+  *              `Random` - output randomly-lengthed chunks of data (Default)
+  *              `OneByOne` - output each byte separately
+  *              `None` - do not fragment packets; output complete chunks immediately after they are produced
   *
   *     - `simulatorHasAccelerometer` - {Boolean} - Sets simulator to send packets with accelerometer data. (Default `true`)
   *
@@ -111,6 +118,10 @@ function OpenBCIFactory () {
     opts.simulatorFirmwareVersion = options.simulatorFirmwareVersion || options.simulatorfirmwareversion || _options.simulatorFirmwareVersion;
     if (opts.simulatorFirmwareVersion !== k.OBCIFirmwareV1 && opts.simulatorFirmwareVersion !== k.OBCIFirmwareV2) {
       opts.simulatorFirmwareVersion = k.OBCIFirmwareV1;
+    }
+    opts.simulatorFragmentation = options.simulatorFragmentation || options.simulatorfragmentation || _options.simulatorFragmentation;
+    if (opts.simulatorFragmentation !== 'Random' && opts.simulatorFragmentation !== 'OneByOne' && opts.simulatorFragmentation !== 'None') {
+      opts.simulatorFragmentation = 'Random';
     }
     if (options.simulatorHasAccelerometer === false || options.simulatorhasaccelerometer === false) {
       opts.simulatorHasAccelerometer = false;

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -130,8 +130,8 @@ function OpenBCIFactory () {
       opts.simulatorFirmwareVersion = k.OBCIFirmwareV1;
     }
     opts.simulatorFragmentation = options.simulatorFragmentation || options.simulatorfragmentation || _options.simulatorFragmentation;
-    if (opts.simulatorFragmentation !== 'random' && opts.simulatorFragmentation !== 'fullBuffers' && opts.simulatorFragmentation !== 'oneByOne' && opts.simulatorFragmentation !== 'none') {
-      opts.simulatorFragmentation = 'random';
+    if (opts.simulatorFragmentation !== k.OBCISimulatorFragmentationRandom && opts.simulatorFragmentation !== k.OBCISimulatorFragmentationFullBuffers && opts.simulatorFragmentation !== k.OBCISimulatorFragmentationOneByOne && opts.simulatorFragmentation !== k.OBCISimulatorFragmentationNone) {
+      opts.simulatorFragmentation = k.OBCISimulatorFragmentationNone;
     }
     opts.simulatorLatencyTime = options.simulatorLatencyTime || options.simulatorlatencytime || _options.simulatorLatencyTime;
     opts.simulatorBufferSize = options.simulatorBufferSize || options.simulatorbuffersize || _options.simulatorBufferSize;

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -1619,6 +1619,8 @@ function OpenBCIFactory () {
           this.curParsingMode = k.OBCIParsingNormal;
           this.buffer = null;
           this.emit('ready');
+        } else {
+          this.buffer = data;
         }
         break;
       case k.OBCIParsingTimeSyncSent:

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -25,7 +25,9 @@ function OpenBCIFactory () {
     simulatorBoardFailure: false,
     simulatorDaisyModuleAttached: false,
     simulatorFirmwareVersion: k.OBCIFirmwareV1,
-    simulatorFragmentation: 'Random',
+    simulatorFragmentation: 'random',
+    simulatorLatencyTime: 16,
+    simulatorBufferSize: 4096,
     simulatorHasAccelerometer: true,
     simulatorInternalClockDrift: 0,
     simulatorInjectAlpha: true,
@@ -68,10 +70,16 @@ function OpenBCIFactory () {
   *              `v2` - Firmware Version 2
   *
   *     - `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation.
-  *          3 Possible Options:
-  *              `Random` - output randomly-lengthed chunks of data (Default)
-  *              `OneByOne` - output each byte separately
-  *              `None` - do not fragment packets; output complete chunks immediately after they are produced
+  *          4 Possible Options:
+  *              `random` - output random small chunks of data interspersed with full buffers (Default)
+  *              `fullBuffers` - allow buffers to fill up until the latency timer has expired
+  *              `oneByOne` - output each byte separately
+  *              `none` - do not fragment packets; output complete chunks immediately after they are produced
+  *
+  *     - `simulatorLatencyTime` {Number} - The time in milliseconds to wait before sending partially full buffers.
+  *                  (Default `16`)
+  *
+  *     - `simulatorBufferSize` {Number} - The size of a full buffer of data. (Default `4096`)
   *
   *     - `simulatorHasAccelerometer` - {Boolean} - Sets simulator to send packets with accelerometer data. (Default `true`)
   *
@@ -81,7 +89,7 @@ function OpenBCIFactory () {
   *          3 Possible Options:
   *              `60Hz` - 60Hz line noise (Default) [America]
   *              `50Hz` - 50Hz line noise [Europe]
-  *              `None` - Do not inject line noise.
+  *              `none` - Do not inject line noise.
   *
   *     - `simulatorSampleRate` {Number} - The sample rate to use for the simulator. Simulator will set to 125 if
   *                  `simulatorDaisyModuleAttached` is set `true`. However, setting this option overrides that
@@ -120,8 +128,8 @@ function OpenBCIFactory () {
       opts.simulatorFirmwareVersion = k.OBCIFirmwareV1;
     }
     opts.simulatorFragmentation = options.simulatorFragmentation || options.simulatorfragmentation || _options.simulatorFragmentation;
-    if (opts.simulatorFragmentation !== 'Random' && opts.simulatorFragmentation !== 'OneByOne' && opts.simulatorFragmentation !== 'None') {
-      opts.simulatorFragmentation = 'Random';
+    if (opts.simulatorFragmentation !== 'random' && opts.simulatorFragmentation !== 'fullBuffers' && opts.simulatorFragmentation !== 'oneByOne' && opts.simulatorFragmentation !== 'none') {
+      opts.simulatorFragmentation = 'random';
     }
     if (options.simulatorHasAccelerometer === false || options.simulatorhasaccelerometer === false) {
       opts.simulatorHasAccelerometer = false;
@@ -135,7 +143,7 @@ function OpenBCIFactory () {
       opts.simulatorInjectAlpha = _options.simulatorInjectAlpha;
     }
     opts.simulatorInjectLineNoise = options.simulatorInjectLineNoise || options.simulatorinjectlinenoise || _options.simulatorInjectLineNoise;
-    if (opts.simulatorInjectLineNoise !== '60Hz' && opts.simulatorInjectLineNoise !== '50Hz' && opts.simulatorInjectLineNoise !== 'None') {
+    if (opts.simulatorInjectLineNoise !== '60Hz' && opts.simulatorInjectLineNoise !== '50Hz' && opts.simulatorInjectLineNoise !== 'none') {
       opts.simulatorInjectLineNoise = '60Hz';
     }
     opts.simulatorSampleRate = options.simulatorSampleRate || options.simulatorsamplerate || _options.simulatorSampleRate;
@@ -245,6 +253,9 @@ function OpenBCIFactory () {
           daisy: this.options.simulatorDaisyModuleAttached,
           drift: this.options.simulatorInternalClockDrift,
           firmwareVersion: this.options.simulatorFirmwareVersion,
+          fragmentation: this.options.simulatorFragmentation,
+          latencyTime: this.options.simulatorLatencyTime,
+          bufferSize: this.options.simulatorBufferSize,
           lineNoise: this.options.simulatorInjectLineNoise,
           sampleRate: this.options.simulatorSampleRate,
           serialPortFailure: this.options.simulatorSerialPortFailure,

--- a/openBCIConstants.js
+++ b/openBCIConstants.js
@@ -193,12 +193,13 @@ const obciBoardGanglion = 'ganglion';
 /** Possible Simulator Line Noise injections */
 const obciSimulatorLineNoiseHz60 = '60Hz';
 const obciSimulatorLineNoiseHz50 = '50Hz';
-const obciSimulatorLineNoiseNone = 'None';
+const obciSimulatorLineNoiseNone = 'none';
 
 /** Possible Simulator Fragmentation modes */
-const obciSimulatorFragmentationRandom = 'Random';
-const obciSimulatorFragmentationOneByOne = 'OneByOne';
-const obciSimulatorFragmentationNone = 'None';
+const obciSimulatorFragmentationRandom = 'random';
+const obciSimulatorFragmentationFullBuffers = 'fullBuffers';
+const obciSimulatorFragmentationOneByOne = 'oneByOne';
+const obciSimulatorFragmentationNone = 'none';
 
 /** Possible Sample Rates */
 const obciSampleRate125 = 125;
@@ -828,6 +829,7 @@ module.exports = {
   OBCISimulatorLineNoiseNone: obciSimulatorLineNoiseNone,
   /** Possible Simulator Fragmentation modes */
   OBCISimulatorFragmentationRandom: obciSimulatorFragmentationRandom,
+  OBCISimulatorFragmentationFullBuffers: obciSimulatorFragmentationFullBuffers,
   OBCISimulatorFragmentationOneByOne: obciSimulatorFragmentationOneByOne,
   OBCISimulatorFragmentationNone: obciSimulatorFragmentationNone,
   /** Firmware version indicator */

--- a/openBCIConstants.js
+++ b/openBCIConstants.js
@@ -195,6 +195,11 @@ const obciSimulatorLineNoiseHz60 = '60Hz';
 const obciSimulatorLineNoiseHz50 = '50Hz';
 const obciSimulatorLineNoiseNone = 'None';
 
+/** Possible Simulator Fragmentation modes */
+const obciSimulatorFragmentationRandom = 'Random';
+const obciSimulatorFragmentationOneByOne = 'OneByOne';
+const obciSimulatorFragmentationNone = 'None';
+
 /** Possible Sample Rates */
 const obciSampleRate125 = 125;
 const obciSampleRate250 = 250;
@@ -821,6 +826,10 @@ module.exports = {
   OBCISimulatorLineNoiseHz60: obciSimulatorLineNoiseHz60,
   OBCISimulatorLineNoiseHz50: obciSimulatorLineNoiseHz50,
   OBCISimulatorLineNoiseNone: obciSimulatorLineNoiseNone,
+  /** Possible Simulator Fragmentation modes */
+  OBCISimulatorFragmentationRandom: obciSimulatorFragmentationRandom,
+  OBCISimulatorFragmentationOneByOne: obciSimulatorFragmentationOneByOne,
+  OBCISimulatorFragmentationNone: obciSimulatorFragmentationNone,
   /** Firmware version indicator */
   OBCIFirmwareV1: obciFirmwareV1,
   OBCIFirmwareV2: obciFirmwareV2,

--- a/openBCISample.js
+++ b/openBCISample.js
@@ -1073,6 +1073,10 @@ function countADSPresent (dataBuffer) {
 * @param dataBuffer - The buffer of some length to parse
 * @returns {boolean} - True if the `$$$` was found.
 */
+// TODO: StreamSearch is optimized to search incoming chunks of data, streaming in,
+//       but a new search is constructed here with every call.  This is not making use
+//       of StreamSearch's optimizations; the object should be preserved between chunks,
+//       and only fed the new data.  TODO: also check other uses of StreamSearch
 function doesBufferHaveEOT (dataBuffer) {
   const s = new StreamSearch(new Buffer(k.OBCIParseEOT));
 

--- a/openBCISample.js
+++ b/openBCISample.js
@@ -1168,6 +1168,9 @@ function isTimeSyncSetConfirmationInBuffer (dataBuffer) {
           return false;
         }
       default:
+        if (dataBuffer[0] === k.OBCISyncTimeSent.charCodeAt(0) && dataBuffer[1] === k.OBCIByteStart) {
+          return true;
+        }
         for (var i = 1; i < bufferLength; i++) {
           // The base case (last one)
           // console.log(i)

--- a/openBCISample.js
+++ b/openBCISample.js
@@ -302,7 +302,7 @@ var sampleModule = {
   * @param lineNoise {String} - A string that can be either:
   *              `60Hz` - 60Hz line noise (Default) (ex. __United States__)
   *              `50Hz` - 50Hz line noise (ex. __Europe__)
-  *              `None` - Do not inject line noise.
+  *              `none` - Do not inject line noise.
   *
   * @returns {Function}
   */

--- a/openBCISample.js
+++ b/openBCISample.js
@@ -1087,7 +1087,7 @@ function doesBufferHaveEOT (dataBuffer) {
   s.push(dataBuffer);
 
   // Check and see if there is a match
-  return s.matches === 1;
+  return s.matches >= 1;
 }
 
 /**
@@ -1105,7 +1105,7 @@ function findV2Firmware (dataBuffer) {
   s.push(dataBuffer);
 
   // Check and see if there is a match
-  return s.matches === 1;
+  return s.matches >= 1;
 }
 
 /**
@@ -1123,7 +1123,7 @@ function isFailureInBuffer (dataBuffer) {
   s.push(dataBuffer);
 
   // Check and see if there is a match
-  return s.matches === 1;
+  return s.matches >= 1;
 }
 
 /**
@@ -1141,7 +1141,7 @@ function isSuccessInBuffer (dataBuffer) {
   s.push(dataBuffer);
 
   // Check and see if there is a match
-  return s.matches === 1;
+  return s.matches >= 1;
 }
 
 /**

--- a/openBCISimulator.js
+++ b/openBCISimulator.js
@@ -18,7 +18,7 @@ function OpenBCISimulatorFactory () {
     daisy: false,
     drift: 0,
     firmwareVersion: k.OBCIFirmwareV1,
-    fragmentation: 'random',
+    fragmentation: k.OBCISimulatorFragmentationNone,
     latencyTime: 16,
     bufferSize: 4096,
     lineNoise: '60Hz',

--- a/openBCISimulator.js
+++ b/openBCISimulator.js
@@ -21,7 +21,8 @@ function OpenBCISimulatorFactory () {
     lineNoise: '60Hz',
     sampleRate: 250,
     serialPortFailure: false,
-    verbose: false
+    verbose: false,
+    fragmentation: 'Random'
   };
 
   function OpenBCISimulator (portName, options) {
@@ -53,6 +54,7 @@ function OpenBCISimulatorFactory () {
     }
     opts.serialPortFailure = options.serialPortFailure || _options.serialPortFailure;
     opts.verbose = options.verbose || _options.verbose;
+    opts.fragmentation = options.fragmentation || _options.fragmentation;
 
     this.options = opts;
 
@@ -66,7 +68,8 @@ function OpenBCISimulatorFactory () {
     this.synced = false;
     this.sendSyncSetPacket = false;
     // Buffers
-    this.buffer = new Buffer(500);
+    this.outputBuffer = new Buffer(500);
+    this.outputBuffered = 0;
     // Numbers
     this.channelNumber = 1;
     this.hostChannelNumber = this.channelNumber;
@@ -91,11 +94,60 @@ function OpenBCISimulatorFactory () {
   }
 
   // This allows us to use the emitter class freely outside of the module
+  // TODO: upgrade from old-style streams to stream.Duplex or stream.Transform
   util.inherits(OpenBCISimulator, stream.Stream);
 
   OpenBCISimulator.prototype.flush = function () {
-    this.buffer.fill(0);
-  // if (this.options.verbose) console.log('flushed')
+    this.outputBuffered = 0;
+
+    clearTimeout(this.outputLoopHandle);
+    this.outputLoopHandle = null;
+  };
+
+  // output only size bytes of the output buffer
+  OpenBCISimulator.prototype._partialDrain = function (size) {
+    if (size > this.outputBuffered) size = this.outputBuffered;
+
+    // buffer is copied because presently openBCIBoard.js reuses it
+    this.emit('data', new Buffer(this.outputBuffer.slice(0, size)));
+
+    this.outputBuffer.copy(this.outputBuffer, 0, size, this.outputBuffered);
+    this.outputBuffered -= size;
+  };
+
+  // queue some data for output and send it out depending on options.fragmentation
+  OpenBCISimulator.prototype._output = function (dataBuffer) {
+    if (this.outputBuffered + dataBuffer.length > this.outputBuffer.length) {
+      this._partialDrain(this.outputBuffered + dataBuffer.length - this.outputBuffer.length);
+    }
+
+    dataBuffer.copy(this.outputBuffer, this.outputBuffered);
+    this.outputBuffered += dataBuffer.length;
+
+    if (!this.outputLoopHandle) {
+      var outputLoop = () => {
+        var size;
+        switch (this.options.fragmentation) {
+          case k.OBCISimulatorFragmentationRandom:
+            size = Math.ceil(Math.random() * this.outputBuffered);
+            break;
+          case k.OBCISimulatorFragmentationOneByOne:
+            size = 1;
+            break;
+          case k.OBCISimulatorFragmentationNone:
+          case false:
+            size = this.outputBuffered;
+            break;
+        }
+        this._partialDrain(size);
+        if (this.outputBuffered) {
+          this.outputLoopHandle = setTimeout(outputLoop, 0);
+        } else {
+          this.outputLoopHandle = null;
+        }
+      };
+      this.outputLoopHandle = setTimeout(outputLoop, 0);
+    }
   };
 
   OpenBCISimulator.prototype.write = function (data, callback) {
@@ -114,7 +166,7 @@ function OpenBCISimulatorFactory () {
       case k.OBCIMiscSoftReset:
         if (this.stream) clearInterval(this.stream);
         this.streaming = false;
-        this.emit('data', new Buffer(`OpenBCI V3 Simulator On Board ADS1299 Device ID: 0x12345 ${this.options.daisy ? `On Daisy ADS1299 Device ID: 0xFFFFF\n` : ``} LIS3DH Device ID: 0x38422 ${this.options.firmware === k.OBCIFirmwareV2 ? `Firmware: v2.0.0\n` : ``}$$$`));
+        this._output(new Buffer(`OpenBCI V3 Simulator On Board ADS1299 Device ID: 0x12345 ${this.options.daisy ? `On Daisy ADS1299 Device ID: 0xFFFFF\n` : ``} LIS3DH Device ID: 0x38422 ${this.options.firmware === k.OBCIFirmwareV2 ? `Firmware: v2.0.0\n` : ``}$$$`));
         break;
       case k.OBCISDLogForHour1:
       case k.OBCISDLogForHour2:
@@ -127,7 +179,7 @@ function OpenBCISimulatorFactory () {
       case k.OBCISDLogForSec14:
         // If we are not streaming, then do verbose output
         if (!this.streaming) {
-          this.emit('data', new Buffer('Wiring is correct and a card is present.\nCorresponding SD file OBCI_69.TXT\n$$$'));
+          this._output(new Buffer('Wiring is correct and a card is present.\nCorresponding SD file OBCI_69.TXT\n$$$'));
         }
         this.sd.active = true;
         this.sd.startTime = now();
@@ -135,13 +187,13 @@ function OpenBCISimulatorFactory () {
       case k.OBCISDLogStop:
         if (!this.streaming) {
           if (this.SDLogActive) {
-            this.emit('data', new Buffer(`Total Elapsed Time: ${now() - this.sd.startTime} ms`));
-            this.emit('data', new Buffer(`Max write time: ${Math.random() * 500} us`));
-            this.emit('data', new Buffer(`Min write time: ${Math.random() * 200} us`));
-            this.emit('data', new Buffer(`Overruns: 0`));
+            this._output(new Buffer(`Total Elapsed Time: ${now() - this.sd.startTime} ms`));
+            this._output(new Buffer(`Max write time: ${Math.random() * 500} us`));
+            this._output(new Buffer(`Min write time: ${Math.random() * 200} us`));
+            this._output(new Buffer(`Overruns: 0`));
             this._printEOT();
           } else {
-            this.emit('data', new Buffer('No open file to close\n'));
+            this._output(new Buffer('No open file to close\n'));
             this._printEOT();
           }
         }
@@ -151,7 +203,7 @@ function OpenBCISimulatorFactory () {
         if (this.options.firmwareVersion === k.OBCIFirmwareV2) {
           this.synced = true;
           setTimeout(() => {
-            this.emit('data', new Buffer(k.OBCISyncTimeSent));
+            this._output(new Buffer(k.OBCISyncTimeSent));
             this._syncUp();
           }, 10);
         }
@@ -210,7 +262,7 @@ function OpenBCISimulatorFactory () {
     };
 
     this.stream = setInterval(() => {
-      this.emit('data', getNewPacket(this.sampleNumber));
+      this._output(getNewPacket(this.sampleNumber));
       this.sampleNumber++;
     }, intervalInMS);
   };
@@ -222,20 +274,20 @@ function OpenBCISimulatorFactory () {
   };
 
   OpenBCISimulator.prototype._printEOT = function () {
-    this.emit('data', new Buffer('$$$'));
+    this._output(new Buffer('$$$'));
   };
 
   OpenBCISimulator.prototype._printFailure = function () {
-    this.emit('data', new Buffer('Failure: '));
+    this._output(new Buffer('Failure: '));
   };
 
   OpenBCISimulator.prototype._printSuccess = function () {
-    this.emit('data', new Buffer('Success: '));
+    this._output(new Buffer('Success: '));
   };
 
   OpenBCISimulator.prototype._printValidatedCommsTimeout = function () {
     this._printFailure();
-    this.emit('data', new Buffer('Communications timeout - Device failed to poll Host'));
+    this._output(new Buffer('Communications timeout - Device failed to poll Host'));
     this._printEOT();
   };
 
@@ -245,13 +297,13 @@ function OpenBCISimulatorFactory () {
         if (this.options.firmwareVersion === k.OBCIFirmwareV2) {
           if (!this.options.boardFailure) {
             this._printSuccess();
-            this.emit('data', new Buffer(`Host and Device on Channel Number ${this.channelNumber}`));
-            this.emit('data', new Buffer([this.channelNumber]));
+            this._output(new Buffer(`Host and Device on Channel Number ${this.channelNumber}`));
+            this._output(new Buffer([this.channelNumber]));
             this._printEOT();
           } else if (!this.serialPortFailure) {
             this._printFailure();
-            this.emit('data', new Buffer(`Host on Channel Number ${this.channelNumber}`));
-            this.emit('data', new Buffer([this.channelNumber]));
+            this._output(new Buffer(`Host on Channel Number ${this.channelNumber}`));
+            this._output(new Buffer([this.channelNumber]));
             this._printEOT();
           }
         }
@@ -263,12 +315,12 @@ function OpenBCISimulatorFactory () {
               this.channelNumber = dataBuffer[2];
               this.hostChannelNumber = this.channelNumber;
               this._printSuccess();
-              this.emit('data', new Buffer(`Channel Number ${this.channelNumber}`));
-              this.emit('data', new Buffer([this.channelNumber]));
+              this._output(new Buffer(`Channel Number ${this.channelNumber}`));
+              this._output(new Buffer([this.channelNumber]));
               this._printEOT();
             } else {
               this._printFailure();
-              this.emit('data', new Buffer('Verify channel number is less than 25'));
+              this._output(new Buffer('Verify channel number is less than 25'));
               this._printEOT();
             }
           } else if (!this.serialPortFailure) {
@@ -286,12 +338,12 @@ function OpenBCISimulatorFactory () {
             }
             this.hostChannelNumber = dataBuffer[2];
             this._printSuccess();
-            this.emit('data', new Buffer(`Host override - Channel Number ${this.hostChannelNumber}`));
-            this.emit('data', new Buffer([this.hostChannelNumber]));
+            this._output(new Buffer(`Host override - Channel Number ${this.hostChannelNumber}`));
+            this._output(new Buffer([this.hostChannelNumber]));
             this._printEOT();
           } else {
             this._printFailure();
-            this.emit('data', new Buffer('Verify channel number is less than 25'));
+            this._output(new Buffer('Verify channel number is less than 25'));
             this._printEOT();
           }
         }
@@ -300,8 +352,8 @@ function OpenBCISimulatorFactory () {
         if (this.options.firmwareVersion === k.OBCIFirmwareV2) {
           if (!this.options.boardFailure) {
             this._printSuccess();
-            this.emit('data', new Buffer(`Poll Time ${this.pollTime}`));
-            this.emit('data', new Buffer([this.pollTime]));
+            this._output(new Buffer(`Poll Time ${this.pollTime}`));
+            this._output(new Buffer([this.pollTime]));
             this._printEOT();
           } else {
             this._printValidatedCommsTimeout();
@@ -313,8 +365,8 @@ function OpenBCISimulatorFactory () {
           if (!this.options.boardFailure) {
             this.pollTime = dataBuffer[2];
             this._printSuccess();
-            this.emit('data', new Buffer(`Poll Time ${this.pollTime}`));
-            this.emit('data', new Buffer([this.pollTime]));
+            this._output(new Buffer(`Poll Time ${this.pollTime}`));
+            this._output(new Buffer([this.pollTime]));
             this._printEOT();
           } else {
             this._printValidatedCommsTimeout();
@@ -324,26 +376,26 @@ function OpenBCISimulatorFactory () {
       case k.OBCIRadioCmdBaudRateSetDefault:
         if (this.options.firmwareVersion === k.OBCIFirmwareV2) {
           this._printSuccess();
-          this.emit('data', new Buffer('Switch your baud rate to 115200'));
-          this.emit('data', new Buffer([0x24, 0x24, 0x24, 0xFF])); // The board really does this
+          this._output(new Buffer('Switch your baud rate to 115200'));
+          this._output(new Buffer([0x24, 0x24, 0x24, 0xFF])); // The board really does this
         }
         break;
       case k.OBCIRadioCmdBaudRateSetFast:
         if (this.options.firmwareVersion === k.OBCIFirmwareV2) {
           this._printSuccess();
-          this.emit('data', new Buffer('Switch your baud rate to 230400'));
-          this.emit('data', new Buffer([0x24, 0x24, 0x24, 0xFF])); // The board really does this
+          this._output(new Buffer('Switch your baud rate to 230400'));
+          this._output(new Buffer([0x24, 0x24, 0x24, 0xFF])); // The board really does this
         }
         break;
       case k.OBCIRadioCmdSystemStatus:
         if (this.options.firmwareVersion === k.OBCIFirmwareV2) {
           if (!this.options.boardFailure) {
             this._printSuccess();
-            this.emit('data', new Buffer('System is Up'));
+            this._output(new Buffer('System is Up'));
             this._printEOT();
           } else {
             this._printFailure();
-            this.emit('data', new Buffer('System is Down'));
+            this._output(new Buffer('System is Down'));
             this._printEOT();
           }
         }

--- a/openBCISimulator.js
+++ b/openBCISimulator.js
@@ -173,6 +173,8 @@ function OpenBCISimulatorFactory () {
   };
 
   OpenBCISimulator.prototype.write = function (data, callback) {
+    // TODO: this function assumes a type of Buffer for radio, and a type of String otherwise
+    //       FIX THIS it makes it unusable outside the api code
     switch (data[0]) {
       case k.OBCIRadioKey:
         this._processPrivateRadioMessage(data);

--- a/test/openBCIBoard-test.js
+++ b/test/openBCIBoard-test.js
@@ -1449,8 +1449,7 @@ $$$`);
         var buf1 = new Buffer(`OpenBCI V3 Simulator
 On Board ADS1299 Device ID: 0x12345
 `);
-        var buf2 = new Buffer(`On Daisy ADS1299 Device ID: 0xFFFFF
-LIS3DH Device ID: `);
+        var buf2 = new Buffer(`LIS3DH Device ID: `);
         var buf3 = new Buffer(`0x38422
 $$$`);
 

--- a/test/openBCIBoard-test.js
+++ b/test/openBCIBoard-test.js
@@ -386,7 +386,10 @@ describe('openbci-sdk', function () {
         simulatorHasAccelerometer: false,
         simulatorInternalClockDrift: -1,
         simulatorInjectAlpha: false,
-        simulatorInjectLineNoise: 'none',
+        simulatorFragmentation: k.OBCISimulatorFragmentationOneByOne,
+        simulatorLatencyTime: 314,
+        simulatorBufferSize: 2718,
+        simulatorInjectLineNoise: k.OBCISimulatorLineNoiseNone,
         simulatorSampleRate: 16,
         simulatorSerialPortFailure: true
       });
@@ -402,6 +405,9 @@ describe('openbci-sdk', function () {
             expect(simOptions.daisy).to.be.true;
             expect(simOptions.drift).to.be.below(0);
             expect(simOptions.firmwareVersion).to.be.equal(k.OBCIFirmwareV2);
+            expect(simOptions.fragmentation).to.be.equal(k.OBCISimulatorFragmentationOneByOne);
+            expect(simOptions.latencyTime).to.be.equal(314);
+            expect(simOptions.bufferSize).to.be.equal(2718);
             expect(simOptions.lineNoise).to.be.equal(k.OBCISimulatorLineNoiseNone);
             expect(simOptions.sampleRate).to.be.equal(16);
             expect(simOptions.serialPortFailure).to.be.true;

--- a/test/openBCIBoard-test.js
+++ b/test/openBCIBoard-test.js
@@ -211,7 +211,7 @@ describe('openbci-sdk', function () {
     });
     it('can turn no line noise on', function () {
       ourBoard = new openBCIBoard.OpenBCIBoard({
-        simulatorInjectLineNoise: 'None'
+        simulatorInjectLineNoise: 'none'
       });
       (ourBoard.options.simulatorInjectLineNoise).should.equal(k.OBCISimulatorLineNoiseNone);
     });
@@ -386,7 +386,7 @@ describe('openbci-sdk', function () {
         simulatorHasAccelerometer: false,
         simulatorInternalClockDrift: -1,
         simulatorInjectAlpha: false,
-        simulatorInjectLineNoise: 'None',
+        simulatorInjectLineNoise: 'none',
         simulatorSampleRate: 16,
         simulatorSerialPortFailure: true
       });
@@ -1754,7 +1754,7 @@ $$$`);
       ourBoard = new openBCIBoard.OpenBCIBoard({
         verbose: true
       });
-      randomSampleGenerator = openBCISample.randomSample(k.OBCINumberOfChannelsDefault, k.OBCISampleRate250, false, 'None');
+      randomSampleGenerator = openBCISample.randomSample(k.OBCINumberOfChannelsDefault, k.OBCISampleRate250, false, 'none');
     });
     beforeEach(() => {
       // Clear the global var

--- a/test/openBCISimulator-test.js
+++ b/test/openBCISimulator-test.js
@@ -35,6 +35,7 @@ describe('openBCISimulator', function () {
       expect(simulator.options.sampleRate).to.equal(k.OBCISampleRate250);
       expect(simulator.options.serialPortFailure).to.be.false;
       expect(simulator.options.verbose).to.be.false;
+      expect(simulator.options.fragmentation).to.equal(k.OBCISimulatorFragmentationRandom);
     });
     it('should be able to get into daisy mode', function () {
       simulator = new openBCISimulator.OpenBCISimulator(portName, {
@@ -113,7 +114,9 @@ describe('openBCISimulator', function () {
   });
   describe(`_startStream`, function () {
     it('should return a packet with sample data in it', function (done) {
-      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName);
+      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
+        fragmentation: k.OBCISimulatorFragmentationNone
+      });
       var sampleCounter = 0;
       var sampleTestSize = 5;
 
@@ -137,7 +140,9 @@ describe('openBCISimulator', function () {
       simulator._startStream();
     });
     it('should return a sync set packet with accel', function (done) {
-      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName);
+      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
+        fragmentation: k.OBCISimulatorFragmentationNone
+      });
       var sampleCounter = 0;
       var sampleTestSize = 5;
 
@@ -170,7 +175,8 @@ describe('openBCISimulator', function () {
     });
     it('should return a sync set packet with raw aux', function (done) {
       var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
-        accel: false
+        accel: false,
+        fragmentation: k.OBCISimulatorFragmentationNone
       });
       var sampleCounter = 0;
       var sampleTestSize = 5;
@@ -207,7 +213,8 @@ describe('openBCISimulator', function () {
     var simulator;
     beforeEach(() => {
       simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
-        firmwareVersion: 'v2'
+        firmwareVersion: 'v2',
+        fragmentation: k.OBCISimulatorFragmentationNone
       });
     });
     afterEach(() => {
@@ -589,7 +596,8 @@ describe('openBCISimulator', function () {
     var simulator;
     beforeEach(function (done) {
       simulator = new openBCISimulator.OpenBCISimulator(portName, {
-        firmwareVersion: 'v2'
+        firmwareVersion: 'v2',
+        fragmentation: k.OBCISimulatorFragmentationNone
       });
       simulator.once('open', () => {
         done();

--- a/test/openBCISimulator-test.js
+++ b/test/openBCISimulator-test.js
@@ -82,7 +82,7 @@ describe('openBCISimulator', function () {
     });
     it('can turn no line noise on', function () {
       simulator = new openBCISimulator.OpenBCISimulator(portName, {
-        lineNoise: 'None'
+        lineNoise: 'none'
       });
       (simulator.options.lineNoise).should.equal(k.OBCISimulatorLineNoiseNone);
     });

--- a/test/openBCISimulator-test.js
+++ b/test/openBCISimulator-test.js
@@ -35,7 +35,9 @@ describe('openBCISimulator', function () {
       expect(simulator.options.sampleRate).to.equal(k.OBCISampleRate250);
       expect(simulator.options.serialPortFailure).to.be.false;
       expect(simulator.options.verbose).to.be.false;
-      expect(simulator.options.fragmentation).to.equal(k.OBCISimulatorFragmentationRandom);
+      expect(simulator.options.fragmentation).to.equal(k.OBCISimulatorFragmentationNone);
+      expect(simulator.options.latencyTime).to.equal(16);
+      expect(simulator.options.bufferSize).to.equal(4096);
     });
     it('should be able to get into daisy mode', function () {
       simulator = new openBCISimulator.OpenBCISimulator(portName, {
@@ -114,9 +116,7 @@ describe('openBCISimulator', function () {
   });
   describe(`_startStream`, function () {
     it('should return a packet with sample data in it', function (done) {
-      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
-        fragmentation: k.OBCISimulatorFragmentationNone
-      });
+      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName);
       var sampleCounter = 0;
       var sampleTestSize = 5;
 
@@ -140,9 +140,7 @@ describe('openBCISimulator', function () {
       simulator._startStream();
     });
     it('should return a sync set packet with accel', function (done) {
-      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
-        fragmentation: k.OBCISimulatorFragmentationNone
-      });
+      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName);
       var sampleCounter = 0;
       var sampleTestSize = 5;
 
@@ -175,8 +173,7 @@ describe('openBCISimulator', function () {
     });
     it('should return a sync set packet with raw aux', function (done) {
       var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
-        accel: false,
-        fragmentation: k.OBCISimulatorFragmentationNone
+        accel: false
       });
       var sampleCounter = 0;
       var sampleTestSize = 5;
@@ -213,8 +210,7 @@ describe('openBCISimulator', function () {
     var simulator;
     beforeEach(() => {
       simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
-        firmwareVersion: 'v2',
-        fragmentation: k.OBCISimulatorFragmentationNone
+        firmwareVersion: 'v2'
       });
     });
     afterEach(() => {
@@ -647,8 +643,7 @@ describe('openBCISimulator', function () {
     var simulator;
     beforeEach(function (done) {
       simulator = new openBCISimulator.OpenBCISimulator(portName, {
-        firmwareVersion: 'v2',
-        fragmentation: k.OBCISimulatorFragmentationNone
+        firmwareVersion: 'v2'
       });
       simulator.once('open', () => {
         done();


### PR DESCRIPTION
This adjusts the simulator to behave a little more like reality, such that packets are split into pieces when received.

I have verified that all of the failing tests are due to issues that this additional simulation reveals, and not bugs in it.  They should be fixed either in the tests or in the main library.