### PR TITLE
Small fixes [for case of packet fragmentation]

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,10 @@
 
 * Implement and adapt semi-standard code style. Closes #83
 
+### Bug Fixes
+
+* Don't drop early packet fragments after board reset
+
 # 1.3.3
 
 ### New Features

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -1597,6 +1597,8 @@ function OpenBCIFactory () {
           this.curParsingMode = k.OBCIParsingNormal;
           this.buffer = null;
           this.emit('ready');
+        } else {
+          this.buffer = data;
         }
         break;
       case k.OBCIParsingTimeSyncSent:

--- a/openBCISample.js
+++ b/openBCISample.js
@@ -1073,6 +1073,10 @@ function countADSPresent (dataBuffer) {
 * @param dataBuffer - The buffer of some length to parse
 * @returns {boolean} - True if the `$$$` was found.
 */
+// TODO: StreamSearch is optimized to search incoming chunks of data, streaming in,
+//       but a new search is constructed here with every call.  This is not making use
+//       of StreamSearch's optimizations; the object should be preserved between chunks,
+//       and only fed the new data.  TODO: also check other uses of StreamSearch
 function doesBufferHaveEOT (dataBuffer) {
   const s = new StreamSearch(new Buffer(k.OBCIParseEOT));
 

--- a/test/openBCIBoard-test.js
+++ b/test/openBCIBoard-test.js
@@ -1449,8 +1449,7 @@ $$$`);
         var buf1 = new Buffer(`OpenBCI V3 Simulator
 On Board ADS1299 Device ID: 0x12345
 `);
-        var buf2 = new Buffer(`On Daisy ADS1299 Device ID: 0xFFFFF
-LIS3DH Device ID: `);
+        var buf2 = new Buffer(`LIS3DH Device ID: `);
         var buf3 = new Buffer(`0x38422
 $$$`);
 

--- a/test/openBCISimulator-test.js
+++ b/test/openBCISimulator-test.js
@@ -35,6 +35,7 @@ describe('openBCISimulator', function () {
       expect(simulator.options.sampleRate).to.equal(k.OBCISampleRate250);
       expect(simulator.options.serialPortFailure).to.be.false;
       expect(simulator.options.verbose).to.be.false;
+      expect(simulator.options.fragmentation).to.equal(k.OBCISimulatorFragmentationRandom);
     });
     it('should be able to get into daisy mode', function () {
       simulator = new openBCISimulator.OpenBCISimulator(portName, {
@@ -113,7 +114,9 @@ describe('openBCISimulator', function () {
   });
   describe(`_startStream`, function () {
     it('should return a packet with sample data in it', function (done) {
-      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName);
+      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
+        fragmentation: k.OBCISimulatorFragmentationNone
+      });
       var sampleCounter = 0;
       var sampleTestSize = 5;
 
@@ -137,7 +140,9 @@ describe('openBCISimulator', function () {
       simulator._startStream();
     });
     it('should return a sync set packet with accel', function (done) {
-      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName);
+      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
+        fragmentation: k.OBCISimulatorFragmentationNone
+      });
       var sampleCounter = 0;
       var sampleTestSize = 5;
 
@@ -170,7 +175,8 @@ describe('openBCISimulator', function () {
     });
     it('should return a sync set packet with raw aux', function (done) {
       var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
-        accel: false
+        accel: false,
+        fragmentation: k.OBCISimulatorFragmentationNone
       });
       var sampleCounter = 0;
       var sampleTestSize = 5;
@@ -207,7 +213,8 @@ describe('openBCISimulator', function () {
     var simulator;
     beforeEach(() => {
       simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
-        firmwareVersion: 'v2'
+        firmwareVersion: 'v2',
+        fragmentation: k.OBCISimulatorFragmentationNone
       });
     });
     afterEach(() => {
@@ -589,7 +596,8 @@ describe('openBCISimulator', function () {
     var simulator;
     beforeEach(function (done) {
       simulator = new openBCISimulator.OpenBCISimulator(portName, {
-        firmwareVersion: 'v2'
+        firmwareVersion: 'v2',
+        fragmentation: k.OBCISimulatorFragmentationNone
       });
       simulator.once('open', () => {
         done();


### PR DESCRIPTION
These adjustments allow the tests to pass if #101 is merged or used.

Incidentally also fixes some initialization issues when communicating with a real live board.