### PR TITLE
Connection fails if already connected (fixes #93)

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -12,12 +12,14 @@
 ### Breaking Changes
 
 * The setting for simulatorInjectLineNoise has changed from `None` to `none`
+* connect() will now fail if already connected
 
 ### Bug Fixes
 
 * Fixed bug where early packet fragments were dropped after board reset
 * Fixed bug where time sync replies that began a buffered chunk were ignored
 * Fixed bug where simulator would output wrong version in its reset message
+* Fixed bug where resources were not cleaned up if connect was called twice
 
 # 1.3.3
 

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -227,9 +227,9 @@ function OpenBCIFactory () {
   * @author AJ Keller (@pushtheworldllc)
   */
   OpenBCIBoard.prototype.connect = function (portName) {
-    this.connected = false;
-
     return new Promise((resolve, reject) => {
+      if (this.connected) return reject('already connected!');
+
       // If we are simulating, set boardSerial to fake name
       var boardSerial;
       /* istanbul ignore else */

--- a/test/openBCIBoard-test.js
+++ b/test/openBCIBoard-test.js
@@ -440,6 +440,15 @@ describe('openbci-sdk', function () {
       if (spy) spy.reset();
     });
     describe('#connect/disconnect/streamStart/streamStop', function () {
+      it('rejects if already connected', function (done) {
+        ourBoard.connect(masterPortName).catch(err => done(err));
+
+        ourBoard.once('ready', () => {
+          ourBoard.connect(masterPortName).should.be.rejected
+            .then(() => ourBoard.disconnect())
+            .should.notify(done);
+        });
+      });
       it('gets the ready signal from the board and sends a stop streaming command before disconnecting', function (done) {
         // spy = sinon.spy(ourBoard,"_writeAndDrain")
 


### PR DESCRIPTION
Resources were not being cleaned up previously.
Although failing is somewhat harsh, this fix makes possible errors more visible.