### PR TITLE
Fix connection-related leaks and inconsistencies

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,6 @@ hardwareVoltageOutputAll.txt
 
 # For git
 *.orig
+
+# Text editor temporary files
+.*.sw* # vi/vim

--- a/README.md
+++ b/README.md
@@ -679,6 +679,16 @@ Sends command to turn off impedances for all channels and stop continuously calc
 
 **_Returns_** a promise, that fulfills when all the commands are sent to the internal write buffer
 
+### <a name="method-is-connected"></a> .isConnected()
+
+Checks if the driver is connected to a board.
+**_Returns_** a boolean, true if connected
+
+### <a name="method-is-streaming"></a> .isStreaming()
+
+Checks if the board is currently sending samples.
+**_Returns_** a boolean, true if streaming
+
 ### <a name="method-list-ports"></a> .listPorts()
 
 List available ports so the user can choose a device when not automatically found.
@@ -1026,13 +1036,13 @@ Either a single character or an Array of characters
 
 Sends a single character command to the board.
 ```js
-// ourBoard has fulfilled the promise on .connected() and 'ready' has been observed previously
+// ourBoard has fulfilled the promise on .connect() and 'ready' has been observed previously
 ourBoard.write('a');
 ```
 
 Sends an array of bytes
 ```js
-// ourBoard has fulfilled the promise on .connected() and 'ready' has been observed previously
+// ourBoard has fulfilled the promise on .connect() and 'ready' has been observed previously
 ourBoard.write(['x','0','1','0','0','0','0','0','0','X']);
 ```
 

--- a/changelog.md
+++ b/changelog.md
@@ -22,6 +22,8 @@
 * Fixed bug where time sync replies that began a buffered chunk were ignored
 * Fixed bug where simulator would output wrong version in its reset message
 * Fixed bug where resources were not cleaned up if connect was called twice
+* Fixed bug where serial data was written after disconnection
+* Fixed bug where unexpected disconnection was not detected
 
 # 1.3.3
 

--- a/changelog.md
+++ b/changelog.md
@@ -4,6 +4,8 @@
 
 * Three new initialization options: `simulatorFragmentation`, `simulatorBufferSize`, and `simulatorLatencyTimer`.  Together, these enable a more _realistic_ serial port simulation, mimicking different potential user computer systems.
 * New option `debug` gives a live dump of serial traffic on the console if enabled
+* New API function `.isConnected()` to check if communications are active.
+* New API function `.isStreaming()` to check if samples are coming from the board.
 
 ### Enhancements
 
@@ -15,6 +17,10 @@
 * The setting for simulatorInjectLineNoise has changed from `None` to `none`
 * connect() will now fail if already connected
 * The constructor will throw an error now if an invalid option is passed
+* The undocumented `.connected` field has been removed, replaced by `.isConnected()`
+* The undocumented `.streaming` field has been removed, replaced by `.isStreaming()`
+* An error event will be emitted if sntp fails to initialize on construction
+* The simulator will no longer communicate when disconnected
 
 ### Bug Fixes
 

--- a/openBCISimulator.js
+++ b/openBCISimulator.js
@@ -93,8 +93,8 @@ function OpenBCISimulatorFactory () {
     // Call 'open'
     if (this.options.verbose) console.log(`Port name: ${portName}`);
     setTimeout(() => {
-      this.emit('open');
       this.connected = true;
+      this.emit('open');
     }, 200);
   }
 
@@ -115,13 +115,17 @@ function OpenBCISimulatorFactory () {
 
   // output only size bytes of the output buffer
   OpenBCISimulator.prototype._partialDrain = function (size) {
+    if (!this.connected) throw new Error('not connected');
+
     if (size > this.outputBuffered) size = this.outputBuffered;
 
     // buffer is copied because presently openBCIBoard.js reuses it
-    this.emit('data', new Buffer(this.outputBuffer.slice(0, size)));
+    var outBuffer = new Buffer(this.outputBuffer.slice(0, size));
 
     this.outputBuffer.copy(this.outputBuffer, 0, size, this.outputBuffered);
     this.outputBuffered -= size;
+
+    this.emit('data', outBuffer);
   };
 
   // queue some data for output and send it out depending on options.fragmentation
@@ -173,11 +177,21 @@ function OpenBCISimulatorFactory () {
           this.outputLoopHandle = null;
         }
       };
-      this.outputLoopHandle = setTimeout(outputLoop, latencyTime);
+      if (latencyTime === 0) {
+        outputLoop();
+      } else {
+        this.outputLoopHandle = setTimeout(outputLoop, latencyTime);
+      }
     }
   };
 
   OpenBCISimulator.prototype.write = function (data, callback) {
+    if (!this.connected) {
+      if (callback) callback('Not connected');
+      else throw new Error('Not connected!');
+      return;
+    }
+
     // TODO: this function assumes a type of Buffer for radio, and a type of String otherwise
     //       FIX THIS it makes it unusable outside the api code
     switch (data[0]) {
@@ -242,21 +256,27 @@ function OpenBCISimulatorFactory () {
     }
 
     /** Handle Callback */
-    if (this.connected) {
+    if (callback) {
       callback(null, 'Success!');
     }
   };
 
   OpenBCISimulator.prototype.drain = function (callback) {
-    callback();
+    if (callback) callback();
   };
 
   OpenBCISimulator.prototype.close = function (callback) {
     if (this.connected) {
+      this.flush();
+
+      if (this.stream) clearInterval(this.stream);
+
+      this.connected = false;
       this.emit('close');
+      if (callback) callback();
+    } else {
+      if (callback) callback('not connected');
     }
-    this.connected = false;
-    callback();
   };
 
   OpenBCISimulator.prototype._startStream = function () {

--- a/openBCISimulator.js
+++ b/openBCISimulator.js
@@ -109,6 +109,10 @@ function OpenBCISimulatorFactory () {
     this.outputLoopHandle = null;
   };
 
+  OpenBCISimulator.prototype.isOpen = function () {
+    return this.connected;
+  };
+
   // output only size bytes of the output buffer
   OpenBCISimulator.prototype._partialDrain = function (size) {
     if (size > this.outputBuffered) size = this.outputBuffered;

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "test": "test"
   },
   "devDependencies": {
+    "bluebird": "3.4.6",
     "chai": "^3.4.1",
     "chai-as-promised": "^5.2.0",
     "codecov": "^1.0.1",

--- a/test/OpenBCIConstants-test.js
+++ b/test/OpenBCIConstants-test.js
@@ -2,6 +2,7 @@
 * Created by ajk on 12/16/15.
 */
 'use strict';
+var bluebirdChecks = require('./bluebirdChecks');
 var assert = require('assert');
 var k = require('../openBCIConstants');
 var chai = require('chai');
@@ -11,6 +12,7 @@ var chaiAsPromised = require('chai-as-promised');
 chai.use(chaiAsPromised);
 
 describe('OpenBCIConstants', function () {
+  afterEach(() => bluebirdChecks.noPendingPromises());
   describe('Turning Channels Off', function () {
     it('channel 1', function () {
       assert.equal('1', k.OBCIChannelOff1);
@@ -793,7 +795,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(2, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[1].should.equal('2');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -801,7 +803,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(5, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[1].should.equal('5');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -809,7 +811,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(9, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[1].should.equal('Q');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -817,7 +819,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(15, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[1].should.equal('U');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -833,7 +835,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[2].should.equal('0');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -841,7 +843,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, true, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[2].should.equal('1');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -854,7 +856,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 1, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[3].should.equal('0');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -862,7 +864,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 2, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[3].should.equal('1');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -870,7 +872,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 4, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[3].should.equal('2');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -878,7 +880,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 6, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[3].should.equal('3');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -886,7 +888,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 8, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[3].should.equal('4');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -894,7 +896,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 12, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[3].should.equal('5');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -902,7 +904,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[3].should.equal('6');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -918,7 +920,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[4].should.equal('0');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -926,7 +928,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'shorted', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[4].should.equal('1');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -934,7 +936,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'biasMethod', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[4].should.equal('2');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -942,7 +944,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'mvdd', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[4].should.equal('3');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -950,7 +952,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'temp', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[4].should.equal('4');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -958,7 +960,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'testSig', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[4].should.equal('5');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -966,7 +968,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'biasDrp', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[4].should.equal('6');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -974,7 +976,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'biasDrn', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[4].should.equal('7');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -990,7 +992,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[5].should.equal('1');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -998,7 +1000,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'normal', false, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[5].should.equal('0');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1011,7 +1013,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[6].should.equal('1');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1019,7 +1021,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'normal', true, false, false).then(function (arrayOfCommands) {
           arrayOfCommands[6].should.equal('0');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1032,7 +1034,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'normal', true, true, true).then(function (arrayOfCommands) {
           arrayOfCommands[7].should.equal('1');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1040,7 +1042,7 @@ describe('OpenBCIConstants', function () {
         k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[7].should.equal('0');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1100,7 +1102,7 @@ describe('OpenBCIConstants', function () {
         k.getImpedanceSetter(2, false, false).then(function (arrayOfCommands) {
           arrayOfCommands[1].should.equal('2');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1108,7 +1110,7 @@ describe('OpenBCIConstants', function () {
         k.getImpedanceSetter(5, false, false).then(function (arrayOfCommands) {
           arrayOfCommands[1].should.equal('5');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1116,7 +1118,7 @@ describe('OpenBCIConstants', function () {
         k.getImpedanceSetter(9, false, false).then(function (arrayOfCommands) {
           arrayOfCommands[1].should.equal('Q');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1124,7 +1126,7 @@ describe('OpenBCIConstants', function () {
         k.getImpedanceSetter(15, false, false).then(function (arrayOfCommands) {
           arrayOfCommands[1].should.equal('U');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1135,12 +1137,12 @@ describe('OpenBCIConstants', function () {
         k.getImpedanceSetter('1', false, false).should.be.rejected.and.notify(done);
       });
     });
-    describe('P Input selection works', function (done) {
-      it('Test Signal Applied', function () {
+    describe('P Input selection works', function () {
+      it('Test Signal Applied', function (done) {
         k.getImpedanceSetter(1, true, false).then(function (arrayOfCommands) {
           arrayOfCommands[2].should.equal('1');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1149,7 +1151,7 @@ describe('OpenBCIConstants', function () {
           console.log('\n\n\narray: ' + arrayOfCommands + '\n\n\n');
           arrayOfCommands[2].should.equal('0');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1157,12 +1159,12 @@ describe('OpenBCIConstants', function () {
         k.getImpedanceSetter(1, 'taco', false).should.be.rejected.and.notify(done);
       });
     });
-    describe('N Input selection works', function (done) {
-      it('Test Signal Applied', function () {
-        k.getImpedanceSetter(1, true, false).then(function (arrayOfCommands) {
+    describe('N Input selection works', function () {
+      it('Test Signal Applied', function (done) {
+        k.getImpedanceSetter(1, false, true).then(function (arrayOfCommands) {
           arrayOfCommands[3].should.equal('1');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1170,7 +1172,7 @@ describe('OpenBCIConstants', function () {
         k.getImpedanceSetter(1, false, false).then(function (arrayOfCommands) {
           arrayOfCommands[3].should.equal('0');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1183,7 +1185,7 @@ describe('OpenBCIConstants', function () {
         k.getImpedanceSetter(1, true, true).then(function (arrayOfCommands) {
           arrayOfCommands[0].should.equal('z');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });
@@ -1191,7 +1193,7 @@ describe('OpenBCIConstants', function () {
         k.getImpedanceSetter(1, true, true).then(function (arrayOfCommands) {
           arrayOfCommands[4].should.equal('Z');
           done();
-        }, function (err) {
+        }).catch(function (err) {
           done(err);
         });
       });

--- a/test/OpenBCISample-test.js
+++ b/test/OpenBCISample-test.js
@@ -1,6 +1,7 @@
 /**
 * Created by ajk on 12/15/15.
 */
+var bluebirdChecks = require('./bluebirdChecks');
 var openBCISample = require('../openBCISample');
 var chai = require('chai');
 var expect = chai.expect;
@@ -27,7 +28,9 @@ describe('openBCISample', function () {
   beforeEach(function () {
     accelArray = [0, 0, 0];
   });
+  afterEach(() => bluebirdChecks.noPendingPromises());
   describe('#parseRawPacketStandard', function () {
+    this.timeout(4000);
     it('should fulfill promise', function () {
       return openBCISample.parseRawPacketStandard(sampleBuf).should.be.fulfilled;
     });
@@ -1439,6 +1442,8 @@ describe('#goertzelProcessSample', function () {
   var numberOfChannels = k.OBCINumberOfChannelsDefault;
   var goertzelObj = openBCISample.goertzelNewObject(numberOfChannels);
   var newRandomSample = openBCISample.randomSample(numberOfChannels, k.OBCISampleRate250);
+
+  afterEach(() => bluebirdChecks.noPendingPromises());
 
   it('produces an array of impedances', function (done) {
     var passed = false;

--- a/test/bluebirdChecks.js
+++ b/test/bluebirdChecks.js
@@ -1,0 +1,142 @@
+var timingEventsAsPromises = require('./timingEventsAsPromises');
+exports.BluebirdPromise = require('bluebird');
+exports.PromiseIgnored = global.Promise;
+
+// Enable bluebird for all promise usage during tests only
+// Fails tests for issues bluebird finds
+// Exports a function to list all promises (getPendingPromises)
+// Exports a function to verify no promises pending within a timeout (noPendingPromises)
+
+exports.BluebirdPromise.config({
+  // TODO: wForgottenReturn is disabled because timingEventsAsPromises triggers it; find a workaround
+  warnings: { wForgottenReturn: false },
+  longStackTraces: true,
+  monitoring: true,
+  cancellation: true
+});
+
+// nextTick conveniently not instrumented by timingEventsAsPromises
+exports.BluebirdPromise.setScheduler(process.nextTick);
+
+// unhandled rejections become test failures
+process.on('unhandledRejection', (reason, promise) => {
+  if (!(reason instanceof Error)) {
+    reason = new Error('unhandled promise rejection: ' + reason);
+  } else {
+    reason.message = 'unhandled promise rejection: ' + reason.message;
+  }
+  process.nextTick(() => { throw reason; });
+});
+
+// // warnings become test failures
+// process.on('warning', (warning) => {
+//   var error = new Error(warning);
+//   process.nextTick(() => { throw error; });
+// });
+
+// provide access to all currently pending promises
+var pendingPromises = {};
+var promiseId = 0;
+var nested = 0;
+
+function promiseCreationHandler (promise) {
+  // promise created already resolved; ignore
+  if (!promise.isPending()) return;
+
+  // need to create another promise to get access to the extended stack trace
+  // nested detects if we are inside our own dummy promise
+  ++nested;
+  if (nested === 1) {
+    // not the dummy promise
+    promise.___id = ++promiseId;
+    // store promise details
+    var error = new Error('Promise ' + promise.___id + ' is still pending');
+    var entry = {
+      promise: promise,
+      id: promise.___id,
+      error: error
+    };
+    pendingPromises[promise.___id] = entry;
+    // extract stack trace by rejecting an error; bluebird fills in expanded stack
+    exports.BluebirdPromise.reject(error).catch(error => {
+      entry.error = error;
+      entry.stack = error.stack;
+    });
+  } else {
+    promise.___nested = nested;
+  }
+  --nested;
+}
+process.on('promiseCreated', promiseCreationHandler);
+
+function promiseDoneHandler (promise) {
+  if (promise.___nested) return;
+  delete pendingPromises[promise.___id];
+}
+process.on('promiseFulfilled', promiseDoneHandler);
+process.on('promiseRejected', promiseDoneHandler);
+process.on('promiseResolved', promiseDoneHandler);
+process.on('promiseCancelled', promiseDoneHandler);
+
+exports.getPendingPromises = function () {
+  var ret = [];
+  for (var promise in pendingPromises) {
+    ret.push(pendingPromises[promise]);
+  }
+  return ret;
+};
+
+exports.noPendingPromises = function (milliseconds) {
+  if (!milliseconds) milliseconds = 0;
+
+  return new exports.PromiseIgnored((resolve, reject) => {
+    function waited100 () {
+      var promises = exports.getPendingPromises();
+
+      if (promises.length === 0) {
+        return resolve();
+      }
+
+      if (milliseconds > 0) {
+        milliseconds -= 100;
+        return timingEventsAsPromises.setTimeoutIgnored(waited100, 100);
+      }
+
+      // timed out, but promises remaining: cancel all
+
+      console.log(promises.length + ' promises still pending');
+
+      promises.forEach(promise => {
+        promise.promise.cancel();
+      });
+
+      // report one
+      reject(promises[0].error);
+    }
+
+    timingEventsAsPromises.setTimeoutIgnored(waited100, 0);
+  });
+};
+
+// now instrument the Promise object itself to always use a simplified version of bluebird
+// bluebird is composed inside a bare-bones Promise object providing only the official calls
+
+global.Promise = function (handler) {
+  this._promise = new exports.BluebirdPromise(handler);
+};
+
+// compose class methods
+['all', 'race', 'reject', 'resolve'].forEach(classMethod => {
+  global.Promise[classMethod] = function () {
+    return exports.BluebirdPromise[classMethod].apply(exports.BluebirdPromise, [].slice.call(arguments));
+  };
+  Object.defineProperty(global.Promise[classMethod], 'name', { value: 'Promise.' + classMethod });
+});
+
+// compose object methods
+['then', 'catch'].forEach(objectMethod => {
+  global.Promise.prototype[objectMethod] = function () {
+    return this._promise[objectMethod].apply(this._promise, [].slice.call(arguments));
+  };
+  Object.defineProperty(global.Promise.prototype[objectMethod], 'name', { value: 'Promise.' + objectMethod });
+});

--- a/test/openBCIBoard-Impedance-test.js
+++ b/test/openBCIBoard-Impedance-test.js
@@ -51,7 +51,7 @@ describe('#impedanceTesting', function () {
     });
   });
   after(done => {
-    if (ourBoard['connected']) {
+    if (ourBoard.isConnected()) {
       ourBoard.disconnect()
         .then(() => {
           done();

--- a/test/openBCIBoard-Impedance-test.js
+++ b/test/openBCIBoard-Impedance-test.js
@@ -1,3 +1,4 @@
+var bluebirdChecks = require('./bluebirdChecks');
 var chai = require('chai');
 var should = chai.should(); // eslint-disable-line no-unused-vars
 var openBCIBoard = require('../openBCIBoard');
@@ -19,7 +20,7 @@ describe('#impedanceTesting', function () {
       simulatorFragmentation: k.OBCISimulatorFragmentationRandom
     });
     var useSim = () => {
-      ourBoard.simulatorEnable().then(() => {
+      return ourBoard.simulatorEnable().then(() => {
         return ourBoard.connect(k.OBCISimulatorPortName);
       });
     };
@@ -28,7 +29,7 @@ describe('#impedanceTesting', function () {
         return ourBoard.connect(portName);
       })
       .catch(() => {
-        useSim();
+        return useSim();
       })
       .then(() => {
         console.log('connected');
@@ -59,8 +60,11 @@ describe('#impedanceTesting', function () {
         .catch(err => {
           done(err);
         });
+    } else {
+      done();
     }
   });
+  after(() => bluebirdChecks.noPendingPromises());
 
   describe('#impedanceTestAllChannels', function () {
     var impedanceArray = [];

--- a/test/openBCISimulator-test.js
+++ b/test/openBCISimulator-test.js
@@ -122,6 +122,35 @@ describe('openBCISimulator', function () {
       } catch (e) { done(); }
     });
   });
+  describe('#write', function () {
+    it('should refuse to write when not connected', function (done) {
+      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName);
+      try {
+        simulator.write('q');
+        done('did not throw on disconnected write');
+      } catch (e) {
+        simulator.write('q', err => {
+          if (err) {
+            done();
+          } else {
+            done('did not provide error on disconnected write');
+          }
+        });
+      }
+    });
+  });
+  describe('#close', function () {
+    it('should provide an error closing when already closed', function (done) {
+      var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName);
+      simulator.close(err => {
+        if (err) {
+          done();
+        } else {
+          done('closed successfully but had no time to open');
+        }
+      });
+    });
+  });
   describe(`_startStream`, function () {
     it('should return a packet with sample data in it', function (done) {
       var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName);

--- a/test/openBCISimulator-test.js
+++ b/test/openBCISimulator-test.js
@@ -1,3 +1,4 @@
+var bluebirdChecks = require('./bluebirdChecks');
 var bufferEqual = require('buffer-equal');
 var chai = require('chai');
 var chaiAsPromised = require(`chai-as-promised`);
@@ -12,6 +13,7 @@ chai.use(chaiAsPromised);
 describe('openBCISimulator', function () {
   this.timeout(4000);
   var portName = k.OBCISimulatorPortName;
+  afterEach(() => bluebirdChecks.noPendingPromises(200));
   describe('#constructor', function () {
     var simulator;
     afterEach(() => {
@@ -163,18 +165,16 @@ describe('openBCISimulator', function () {
           simulator.removeListener('data', newDataFunc);
           openBCISample.parseRawPacketStandard(data, k.channelSettingsArrayInit(k.OBCINumberOfChannelsDefault), true)
             .then(sampleObject => {
-              sampleObject.channelData.forEach((channelValue, index) => {
-                expect(channelValue).to.not.equal(0);
-              });
+              expect(sampleObject.channelData).to.not.all.equal(0);
               simulator = null;
               done();
-            });
+            }).catch(err => done(err));
         } else {
           sampleCounter++;
         }
       };
       simulator.on('data', newDataFunc);
-      simulator._startStream();
+      simulator.once('open', () => simulator._startStream());
     });
     it('should return a sync set packet with accel', function (done) {
       var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName);
@@ -206,7 +206,7 @@ describe('openBCISimulator', function () {
       };
 
       simulator.on('data', newDataFunc);
-      simulator._startStream();
+      simulator.once('open', () => simulator.write(k.OBCIStreamStart));
     });
     it('should return a sync set packet with raw aux', function (done) {
       var simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
@@ -239,15 +239,16 @@ describe('openBCISimulator', function () {
       };
 
       simulator.on('data', newDataFunc);
-      simulator._startStream();
+      simulator.once('open', () => simulator.write(k.OBCIStreamStart));
     });
   });
   describe(`firmwareVersion1`, function () {
     var simulator;
-    beforeEach(() => {
+    beforeEach((done) => {
       simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
         firmwareVersion: 'v1'
       });
+      simulator.once('open', done);
     });
     afterEach(() => {
       simulator = null;
@@ -265,10 +266,11 @@ describe('openBCISimulator', function () {
   });
   describe(`firmwareVersion2`, function () {
     var simulator;
-    beforeEach(() => {
+    beforeEach((done) => {
       simulator = new openBCISimulator.OpenBCISimulator(k.OBCISimulatorPortName, {
         firmwareVersion: 'v2'
       });
+      simulator.once('open', done);
     });
     afterEach(() => {
       simulator = null;
@@ -670,7 +672,7 @@ describe('openBCISimulator', function () {
         expect(buffer.length).to.equal(bufferSize);
         done();
       });
-      simulator.write(k.OBCIStreamStart);
+      simulator.once('open', () => simulator.write(k.OBCIStreamStart));
     });
     it('Should emit partial packets after latencyTime', function (done) {
       var bufferSize = 4096;
@@ -679,11 +681,11 @@ describe('openBCISimulator', function () {
         bufferSize: 4096,
         latencyTime: 0
       });
-      simulator.on('data', function (buffer) {
+      simulator.once('data', function (buffer) {
         expect(buffer.length).to.be.lessThan(bufferSize);
         done();
       });
-      simulator.write(k.OBCIStreamStart);
+      simulator.once('open', () => simulator.write(k.OBCIStreamStart));
     });
     it('Should emit single bytes if set to OneByOne', function (done) {
       simulator = new openBCISimulator.OpenBCISimulator(portName, {
@@ -696,7 +698,7 @@ describe('openBCISimulator', function () {
 
         if (counter === 5) done();
       });
-      simulator.write(k.OBCIStreamStart);
+      simulator.once('open', () => simulator.write(k.OBCIStreamStart));
     });
     it('should properly split packets, retaining valid packets', function (done) {
       simulator = new openBCISimulator.OpenBCISimulator(portName, {
@@ -714,7 +716,7 @@ describe('openBCISimulator', function () {
           }, done);
         }
       });
-      simulator.write(k.OBCIStreamStart);
+      simulator.once('open', () => simulator.write(k.OBCIStreamStart));
     });
   });
   describe(`boardFailure`, function () {});

--- a/test/timingEventsAsPromises.js
+++ b/test/timingEventsAsPromises.js
@@ -1,0 +1,108 @@
+// Converts timing events to use promises, to gain bluebird's checks
+
+function instrumentTimingEvents (module, type) {
+  // replaces module[type] with a function that does the same thing but uses a promise
+  // assumes the first argument will be to a callback function
+
+  // if this a setSomething function with a clearSomething partner, the partner will also be instrumented
+  var setName = type;
+  var clearName = null;
+  if (type.substring(0, 3) === 'set') {
+    clearName = 'clear' + type.substring(3);
+  }
+
+  if (!module[setName]) return;
+
+  // store original functions
+  var originalSet = module[setName];
+  var originalClear = module[clearName];
+  exports[setName + 'Ignored'] = originalSet;
+
+  // dictionary to store promise details for each call
+  var events = {};
+
+  // setAsPromise() is the brunt of the function.  It replaces the previous global function,
+  // and sets up a promise to resolve when the callback is called
+  var eventCount = 0;
+  var setAsPromise = function (callback) {
+    var args = [].slice.call(arguments);
+
+    var eventNum = ++eventCount;
+    var eventHandle;
+
+    if (setAsPromise._ignoreCount > 0) {
+      --setAsPromise._ignoreCount;
+
+      return originalSet.apply(this, args);
+    }
+
+    // actual callback is replaced by promise resolve
+    args[0] = function () {
+      if (!events[eventNum]) throw new Error(setName + ' ' + eventNum + ' disappeared');
+      events[eventNum].resolve([].slice.call(arguments));
+    };
+
+    eventHandle = originalSet.apply(this, args) || eventNum;
+
+    // this portion is a function so that setInterval may be handled via recursion
+    function dispatch () {
+      var handlerDetails = { handle: eventHandle };
+
+      var promise = new Promise((resolve, reject) => {
+        handlerDetails.resolve = resolve;
+        handlerDetails.reject = reject;
+      });
+
+      handlerDetails.promise = promise;
+      events[eventNum] = handlerDetails;
+
+      promise.then(function (argumentArray) {
+        if (type !== 'setInterval') {
+          delete events[eventNum];
+        } else {
+          dispatch();
+        }
+
+        // call original handler
+        callback.apply(this, argumentArray);
+      }, () => {
+        originalClear(eventHandle);
+        delete events[eventNum];
+      });
+
+      return promise;
+    }
+
+    dispatch();
+
+    return eventNum;
+  };
+
+  // actually replace functions with instrumented ones
+  setAsPromise._ignoreCount = 0;
+  module[setName] = setAsPromise;
+  Object.defineProperty(setAsPromise, 'name', { value: setName + 'AsPromise' });
+
+  if (clearName) {
+    module[clearName] = (eventNum) => {
+      if (!events[eventNum]) {
+        originalClear(eventNum);
+      } else {
+        events[eventNum].reject(new Error('cleared'));
+      }
+    };
+    Object.defineProperty(module[clearName], 'name', { value: clearName + 'AsPromise' });
+  }
+}
+
+instrumentTimingEvents(global, 'setTimeout');
+instrumentTimingEvents(global, 'setInterval');
+instrumentTimingEvents(global, 'setImmediate');
+// // Possible TODO: nextTick needs some exceptions included to prevent infinite recursion
+// instrumentTimingEvents(process, 'nextTick');
+
+// the next call to the passed function should not be promisified
+// may be queued multiple times
+exports.ignoreOnce = (ignored) => {
+  ignored._ignoreCount ++;
+};


### PR DESCRIPTION
Fixes #92

Notable changes:
- Added a utils test file that tracks `setTimeout()` and `setInterval()` uses that are never `clear`ed.
- Changed `.connected` to `.isConnected()` so that it may be part of the public API
- Paired uses of `.sntpStart` with matching `.sntpStop`
- Raise a few more errors in places where exceptional things happen
- Handled all forms of disconnection and cleaned up state 
