### PR TITLE
Fragmented and Buffered Samples (#115)

### DIFF
--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -1692,7 +1692,7 @@ function OpenBCIFactory () {
         if (openBCISample.doesBufferHaveEOT(data)) {
           this.curParsingMode = k.OBCIParsingNormal;
           this.emit('eot', data);
-          this.buffer = null;
+          this.buffer = openBCISample.stripToEOTBuffer(data);
         } else {
           this.buffer = data;
         }
@@ -1702,8 +1702,8 @@ function OpenBCIFactory () {
         if (openBCISample.doesBufferHaveEOT(data)) {
           this._processParseBufferForReset(data);
           this.curParsingMode = k.OBCIParsingNormal;
-          this.buffer = null;
           this.emit('ready');
+          this.buffer = openBCISample.stripToEOTBuffer(data);
         } else {
           this.buffer = data;
         }
@@ -1795,11 +1795,12 @@ function OpenBCIFactory () {
   };
 
   /**
-  * @description Alters the global info object by parseing an incoming soft reset key
-  * @param dataBuffer {Buffer} - The soft reset data buffer
-  * @private
-  * @author AJ Keller (@pushtheworldllc)
-  */
+   * @description Alters the global info object by parseing an incoming soft reset key
+   * @param dataBuffer {Buffer} - The soft reset data buffer
+   * @returns {Buffer} - If there is data left in the buffer, just it will be returned.
+   * @private
+   * @author AJ Keller (@pushtheworldllc)
+   */
   OpenBCIBoard.prototype._processParseBufferForReset = function (dataBuffer) {
     if (openBCISample.countADSPresent(dataBuffer) === 2) {
       this.info.boardType = k.OBCIBoardDaisy;

--- a/openBCISample.js
+++ b/openBCISample.js
@@ -522,6 +522,7 @@ var sampleModule = {
   makeTailByteFromPacketType,
   isStopByte,
   newSyncObject,
+  stripToEOTBuffer,
   /**
   * @description Checks to make sure the previous sample number is one less
   *  then the new sample number. Takes into account sample numbers wrapping
@@ -1109,6 +1110,31 @@ function isSuccessInBuffer (dataBuffer) {
 
   // Check and see if there is a match
   return s.matches >= 1;
+}
+
+/**
+ * @description Used to slice a buffer for the EOT '$$$'.
+ * @param dataBuffer {Buffer} - The buffer of some length to parse
+ * @returns {Buffer} - The remaining buffer.
+ */
+function stripToEOTBuffer (dataBuffer) {
+  let indexOfEOT = dataBuffer.indexOf(k.OBCIParseEOT);
+  if (indexOfEOT > 0) {
+    indexOfEOT += k.OBCIParseEOT.length;
+  } else {
+    return dataBuffer;
+  }
+
+  if (indexOfEOT < dataBuffer.byteLength) {
+    if (k.getVersionNumber(process.version) >= 6) {
+      // From introduced in node version 6.x.x
+      return Buffer.from(dataBuffer.slice(indexOfEOT));
+    } else {
+      return new Buffer(dataBuffer.slice(indexOfEOT));
+    }
+  } else {
+    return null;
+  }
 }
 
 /**

--- a/test/OpenBCISample-test.js
+++ b/test/OpenBCISample-test.js
@@ -1210,6 +1210,52 @@ $$$`);
       expect(openBCISample.droppedPacketCheck(previous, current)).to.be.null;
     });
   });
+  describe('#stripToEOTBuffer', function() {
+    it('should return the buffer if no EOT', function () {
+      let buf = null;
+      if (k.getVersionNumber(process.version) >= 6) {
+        // From introduced in node version 6.x.x
+        buf = Buffer.from('tacos are delicious');
+      } else {
+        buf = new Buffer('tacos are delicious');
+      }
+      expect(openBCISample.stripToEOTBuffer(buf).toString()).to.equal(buf.toString());
+    });
+    it('should slice the buffer after eot $$$', function() {
+      let bufPre = null;
+      let eotBuf = null;
+      let bufPost = null;
+      if (k.getVersionNumber(process.version) >= 6) {
+        // From introduced in node version 6.x.x
+        bufPre = Buffer.from('tacos are delicious');
+        eotBuf = Buffer.from(k.OBCIParseEOT);
+        bufPost = Buffer.from('tacos');
+      } else {
+        bufPre = new Buffer('tacos are delicious');
+        eotBuf = new Buffer(k.OBCIParseEOT);
+        bufPost = new Buffer('tacos');
+      }
+
+      let totalBuf = Buffer.concat([bufPre, eotBuf, bufPost]);
+      expect(openBCISample.stripToEOTBuffer(totalBuf).toString()).to.equal(bufPost.toString());
+    });
+    it('should return null if nothing left', function () {
+      let bufPre = null;
+      let eotBuf = null;
+      let bufPost = null;
+      if (k.getVersionNumber(process.version) >= 6) {
+        // From introduced in node version 6.x.x
+        bufPre = Buffer.from('tacos are delicious');
+        eotBuf = Buffer.from(k.OBCIParseEOT);
+      } else {
+        bufPre = new Buffer('tacos are delicious');
+        eotBuf = new Buffer(k.OBCIParseEOT);
+      }
+
+      let totalBuf = Buffer.concat([bufPre, eotBuf]);
+      expect(openBCISample.stripToEOTBuffer(totalBuf)).to.equal(null);
+    });
+  })
 });
 
 describe('#goertzelProcessSample', function () {

--- a/test/OpenBCISample-test.js
+++ b/test/OpenBCISample-test.js
@@ -1210,7 +1210,7 @@ $$$`);
       expect(openBCISample.droppedPacketCheck(previous, current)).to.be.null;
     });
   });
-  describe('#stripToEOTBuffer', function() {
+  describe('#stripToEOTBuffer', function () {
     it('should return the buffer if no EOT', function () {
       let buf = null;
       if (k.getVersionNumber(process.version) >= 6) {
@@ -1221,7 +1221,7 @@ $$$`);
       }
       expect(openBCISample.stripToEOTBuffer(buf).toString()).to.equal(buf.toString());
     });
-    it('should slice the buffer after eot $$$', function() {
+    it('should slice the buffer after eot $$$', function () {
       let bufPre = null;
       let eotBuf = null;
       let bufPost = null;
@@ -1242,7 +1242,6 @@ $$$`);
     it('should return null if nothing left', function () {
       let bufPre = null;
       let eotBuf = null;
-      let bufPost = null;
       if (k.getVersionNumber(process.version) >= 6) {
         // From introduced in node version 6.x.x
         bufPre = Buffer.from('tacos are delicious');
@@ -1255,7 +1254,7 @@ $$$`);
       let totalBuf = Buffer.concat([bufPre, eotBuf]);
       expect(openBCISample.stripToEOTBuffer(totalBuf)).to.equal(null);
     });
-  })
+  });
 });
 
 describe('#goertzelProcessSample', function () {


### PR DESCRIPTION
For now this is just a failing test for #115.

So far it looks like there are two issues: the first packet is dropped after the fragmented reset response (unless my understanding of sample numbers is faulty), and only the first two packets of the large buffered clump are processed.

I've also noticed while working with the relevant daisy test, that most of the time the board is not detected as being a daisy board, and the whole test is skipped.  I think this is why it usually passes.