### PR TITLE
1.4.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ The purpose of this module is to **get connected** and **start streaming** as fa
   4. [Constants](#constants)
 6. [Interfacing With Other Tools](#interfacing-with-other-tools)
 7. [Developing](#developing)
-8. [Testing](#testing)
+8. [Testing](#developing-testing)
 9. [Contribute](#contribute)
 10. [License](#license)
 11. [Roadmap](#roadmap)
@@ -846,7 +846,7 @@ To leave simulate mode.
 
 ### <a name="method-sntp"></a> .sntp
 
-Extends the popular STNP package on [npmjs](https://www.npmjs.com/package/sntp)
+Extends the popular SNTP package on [npmjs](https://www.npmjs.com/package/sntp)
 
 ### <a name="method-sntp-get-offset"></a> .sntpGetOffset()
 
@@ -1166,13 +1166,14 @@ npm test
 ## <a name="contribute"></a> Contribute:
 
 1. Fork it!
+2. Branch off of `development`: `git checkout development`
 2. Create your feature branch: `git checkout -b my-new-feature`
 3. Make changes
 4. If adding a feature, please add test coverage.
 5. Ensure tests all pass. (`npm test`)
 6. Commit your changes: `git commit -m 'Add some feature'`
 7. Push to the branch: `git push origin my-new-feature`
-8. Submit a pull request :D
+8. Submit a pull request. Make sure it is based off of the `development` branch when submitting! :D
 
 ## <a name="license"></a> License:
 

--- a/changelog.md
+++ b/changelog.md
@@ -28,6 +28,7 @@
 * The `.streaming` property has been removed, replaced by `.isStreaming()`. Removed from docs.
 * An error event will be emitted if sntp fails to initialize on construction
 * The simulator will no longer communicate when disconnected
+* Promises returned by writes will now only resolve after the write has been sent
 
 ### Bug Fixes
 

--- a/changelog.md
+++ b/changelog.md
@@ -2,6 +2,7 @@
 
 ### Bug Fixes
 * Fixes bug where extra data after EOT (`$$$`) was dumped by preserving the poriton after the EOT for further decomposition.
+* Fixes bug where any calls to channel set would actually break the openBCISample code as the channelSettingsArray contained an undefined.
 
 # 1.4.0
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,8 @@
+# 1.4.1
+
+### Bug Fixes
+* Fixes bug where extra data after EOT (`$$$`) was dumped by preserving the poriton after the EOT for further decomposition.
+
 # 1.4.0
 
 ### New Features

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -1692,7 +1692,7 @@ function OpenBCIFactory () {
         if (openBCISample.doesBufferHaveEOT(data)) {
           this.curParsingMode = k.OBCIParsingNormal;
           this.emit('eot', data);
-          this.buffer = null;
+          this.buffer = openBCISample.stripToEOTBuffer(data);
         } else {
           this.buffer = data;
         }
@@ -1702,8 +1702,8 @@ function OpenBCIFactory () {
         if (openBCISample.doesBufferHaveEOT(data)) {
           this._processParseBufferForReset(data);
           this.curParsingMode = k.OBCIParsingNormal;
-          this.buffer = null;
           this.emit('ready');
+          this.buffer = openBCISample.stripToEOTBuffer(data);
         } else {
           this.buffer = data;
         }
@@ -1795,11 +1795,12 @@ function OpenBCIFactory () {
   };
 
   /**
-  * @description Alters the global info object by parseing an incoming soft reset key
-  * @param dataBuffer {Buffer} - The soft reset data buffer
-  * @private
-  * @author AJ Keller (@pushtheworldllc)
-  */
+   * @description Alters the global info object by parseing an incoming soft reset key
+   * @param dataBuffer {Buffer} - The soft reset data buffer
+   * @returns {Buffer} - If there is data left in the buffer, just it will be returned.
+   * @private
+   * @author AJ Keller (@pushtheworldllc)
+   */
   OpenBCIBoard.prototype._processParseBufferForReset = function (dataBuffer) {
     if (openBCISample.countADSPresent(dataBuffer) === 2) {
       this.info.boardType = k.OBCIBoardDaisy;

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -1092,9 +1092,9 @@ function OpenBCIFactory () {
     var arrayOfCommands = [];
     return new Promise((resolve, reject) => {
       k.getChannelSetter(channelNumber, powerDown, gain, inputType, bias, srb2, srb1)
-        .then((arr, newChannelSettingObject) => {
-          arrayOfCommands = arr;
-          this.channelSettingsArray[channelNumber - 1] = newChannelSettingObject;
+        .then((val) => {
+          arrayOfCommands = val.commandArray;
+          this.channelSettingsArray[channelNumber - 1] = val.newChannelSettingsObject;
           resolve(this.write(arrayOfCommands));
         }, function (err) {
           reject(err);

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -157,7 +157,7 @@ function OpenBCIFactory () {
     // Arrays
     this.accelArray = [0, 0, 0]; // X, Y, Z
     this.channelSettingsArray = k.channelSettingsArrayInit(k.numberOfChannelsForBoardType(this.options.boardType));
-    this.writeOutArray = new Array(100);
+    this.writeOutArray = [];
     // Booleans
     this._streaming = false;
     // Buffers
@@ -200,7 +200,6 @@ function OpenBCIFactory () {
     // Numbers
     this.badPackets = 0;
     this.curParsingMode = k.OBCIParsingReset;
-    this.commandsToWrite = 0;
     this.impedanceArray = openBCISample.impedanceArray(k.numberOfChannelsForBoardType(this.options.boardType));
     this.previousSampleNumber = -1;
     this.sampleCount = 0;
@@ -281,29 +280,42 @@ function OpenBCIFactory () {
         this._processBytes(data);
       });
       this.serial.once('open', () => {
-        var timeoutLength = this.options.simulate ? 50 : 300;
         if (this.options.verbose) console.log('Serial port open');
-        setTimeout(() => {
+        new Promise(resolve => {
+          // TODO: document why this 300 ms delay is needed
+          setTimeout(resolve, this.options.simulate ? 50 : 300);
+        }).then(() => {
           if (this.options.verbose) console.log('Sending stop command, in case the device was left streaming...');
-          this.write(k.OBCIStreamStop);
-          if (this.serial) this.serial.flush();
-        }, timeoutLength);
-        setTimeout(() => {
+          return this.write(k.OBCIStreamStop);
+        }).then(() => {
+          return new Promise(resolve => this.serial.flush(resolve));
+        }).then(() => {
+          // TODO: document why this 250 ms delay is needed
+          return new Promise(resolve => setTimeout(resolve, 250));
+        }).then(() => {
           if (this.options.verbose) console.log('Sending soft reset');
-          this.softReset();
+          // TODO: this promise chain resolves early because
+          //  A. some legacy code (in tests) sets the ready handler after this resolves
+          // and
+          //  B. other legacy code (in tests) needs the simulator to reply with segmented packets, never fragmented
+          // which is C. not implemented yet except in a manner such that replies occur in the write handler,
+          // resulting in the EOT arriving before this resolves
+          // Fix one or more of the above 3 situations, then move resolve() to the next block.
           resolve();
+          return this.softReset();
+        }).then(() => {
           if (this.options.verbose) console.log("Waiting for '$$$'");
-        }, timeoutLength + 250);
+        });
       });
       this.serial.once('close', () => {
         if (this.options.verbose) console.log('Serial Port Closed');
         // 'close' is emitted in _disconnected()
-        this._disconnected();
+        this._disconnected('port closed');
       });
       this.serial.once('error', (err) => {
         if (this.options.verbose) console.log('Serial Port Error');
         this.emit('error', err);
-        this._disconnected();
+        this._disconnected(err);
       });
     });
   };
@@ -312,10 +324,9 @@ function OpenBCIFactory () {
   * @description Called once when for any reason the serial port is no longer open.
   * @private
   */
-  OpenBCIBoard.prototype._disconnected = function () {
+  OpenBCIBoard.prototype._disconnected = function (err) {
     this._streaming = false;
 
-    this.commandsToWrite = 0;
     clearTimeout(this.writer);
     this.writer = null;
 
@@ -323,6 +334,11 @@ function OpenBCIFactory () {
     this.serial = null;
 
     this.emit('close');
+
+    while (this.writeOutArray.length > 0) {
+      var command = this.writeOutArray.pop();
+      if (command.reject) command.reject(err);
+    }
   };
 
   /**
@@ -332,9 +348,6 @@ function OpenBCIFactory () {
   * @author AJ Keller (@pushtheworldllc)
   */
   OpenBCIBoard.prototype.disconnect = function () {
-    if (!this.isConnected()) return Promise.reject('no board connected');
-
-    // no need for timeout here; streamStop already performs a delay
     return Promise.resolve()
       .then(() => {
         if (this.isStreaming()) {
@@ -343,12 +356,16 @@ function OpenBCIFactory () {
         }
       })
       .then(() => {
-        return new Promise((resolve, reject) => {
-          // serial emitting 'close' will call _disconnected
-          this.serial.close(() => {
-            resolve();
+        if (!this.isConnected()) {
+          return Promise.reject('no board connected');
+        } else {
+          return new Promise((resolve, reject) => {
+            // serial emitting 'close' will call _disconnected
+            this.serial.close(() => {
+              resolve();
+            });
           });
-        });
+        }
       });
   };
 
@@ -382,13 +399,7 @@ function OpenBCIFactory () {
       if (this.isStreaming()) return reject('Error [.streamStart()]: Already streaming');
       this._streaming = true;
       this._reset_ABANDONED(); // framework is incomplete but looks useful
-      this.write(k.OBCIStreamStart)
-        .then(() => {
-          setTimeout(() => {
-            resolve();
-          }, 10); // allow time for command to get sent
-        })
-        .catch(err => reject(err));
+      this.write(k.OBCIStreamStart).then(resolve, reject);
     });
   };
 
@@ -404,13 +415,7 @@ function OpenBCIFactory () {
     return new Promise((resolve, reject) => {
       if (!this.isStreaming()) return reject('Error [.streamStop()]: No stream to stop');
       this._streaming = false;
-      this.write(k.OBCIStreamStop)
-        .then(() => {
-          setTimeout(() => {
-            resolve();
-          }, 10); // allow time for command to get sent
-        })
-        .catch(err => reject(err));
+      this.write(k.OBCIStreamStop).then(resolve, reject);
     });
   };
 
@@ -462,50 +467,55 @@ function OpenBCIFactory () {
 
   /**
   * @description To be able to easily write to the board but ensure that we never send commands
-  *              with less than a 10ms spacing between sends. This uses an array and pops off
-  *              the entries until there are none left.
+  *              with less than a 10ms spacing between sends in early version boards. This uses
+  *              an array and shifts off the entries until there are none left.
   * @param dataToWrite - Either a single character or an Array of characters
   * @returns {Promise}
   * @author AJ Keller (@pushtheworldllc)
   */
   OpenBCIBoard.prototype.write = function (dataToWrite) {
-    var writerFunction = () => {
-      /* istanbul ignore else */
-      if (this.commandsToWrite > 0) {
-        var command = this.writeOutArray.shift();
-        this.commandsToWrite--;
-        if (this.commandsToWrite === 0) {
-          this.writer = null;
+    return new Promise((resolve, reject) => {
+      if (!this.isConnected()) {
+        reject('not connected');
+      } else {
+        if (Array.isArray(dataToWrite)) { // Got an input array
+          var len = dataToWrite.length;
+          for (var i = 0; i < len; i++) {
+            this.writeOutArray.push({ cmd: dataToWrite[i], reject: reject });
+          }
+          this.writeOutArray[this.writeOutArray.length - 1].resolve = resolve;
         } else {
+          this.writeOutArray.push({ cmd: dataToWrite, reject: reject, resolve: resolve });
+        }
+
+        if (!this.writer) { // there is no writer started
+          var writerFunction = () => {
+            if (this.writeOutArray.length === 0) {
+              this.writer = null;
+              return;
+            }
+
+            var command = this.writeOutArray.shift();
+            var promise = this._writeAndDrain(command.cmd);
+
+            promise.then(() => {
+              this.writer = setTimeout(writerFunction, this.writeOutDelay);
+            }, () => {
+              // write failed but more commands may be pending that need a result
+              writerFunction();
+            });
+
+            if (command.reject) {
+              promise.catch(err => {
+                if (this.options.verbose) console.log('write failure: ' + err);
+                command.reject(err);
+              });
+            }
+            if (command.resolve) promise.then(command.resolve);
+          };
           this.writer = setTimeout(writerFunction, this.writeOutDelay);
         }
-        this._writeAndDrain(command)
-          .catch(err => {
-            /* istanbul ignore if */
-            if (this.options.verbose) console.log('write failure: ' + err);
-          });
-      } else {
-        if (this.options.verbose) console.log('Big problem! Writer started with no commands to write');
       }
-    };
-
-    return new Promise((resolve, reject) => {
-      // console.log('write method called')
-      if (!this.isConnected()) return reject('not connected');
-      if (Array.isArray(dataToWrite)) { // Got an input array
-        var len = dataToWrite.length;
-        for (var i = 0; i < len; i++) {
-          this.writeOutArray[this.commandsToWrite] = dataToWrite[i];
-          this.commandsToWrite++;
-        }
-      } else {
-        this.writeOutArray[this.commandsToWrite] = dataToWrite;
-        this.commandsToWrite++;
-      }
-      if (this.writer === null || this.writer === undefined) { // there is no writer started
-        this.writer = setTimeout(writerFunction, this.writeOutDelay);
-      }
-      resolve();
     });
   };
 
@@ -651,7 +661,7 @@ function OpenBCIFactory () {
       this.curParsingMode = k.OBCIParsingEOT;
 
       // Send the radio channel query command
-      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdChannelSet, channelNumber]));
+      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdChannelSet, channelNumber])).catch(reject);
     });
   };
 
@@ -701,7 +711,7 @@ function OpenBCIFactory () {
       this.curParsingMode = k.OBCIParsingEOT;
 
       // Send the radio channel query command
-      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdChannelSetOverride, channelNumber]));
+      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdChannelSetOverride, channelNumber])).catch(reject);
     });
   };
 
@@ -751,7 +761,7 @@ function OpenBCIFactory () {
       this.curParsingMode = k.OBCIParsingEOT;
 
       // Send the radio channel query command
-      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdChannelGet]));
+      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdChannelGet])).catch(reject);
     });
   };
 
@@ -797,7 +807,7 @@ function OpenBCIFactory () {
       this.curParsingMode = k.OBCIParsingEOT;
 
       // Send the radio channel query command
-      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdPollTimeGet]));
+      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdPollTimeGet])).catch(reject);
     });
   };
 
@@ -848,7 +858,7 @@ function OpenBCIFactory () {
       this.curParsingMode = k.OBCIParsingEOT;
 
       // Send the radio channel query command
-      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdPollTimeSet, pollTime]));
+      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdPollTimeSet, pollTime])).catch(reject);
     });
   };
 
@@ -920,9 +930,9 @@ function OpenBCIFactory () {
 
       // Send the radio channel query command
       if (speed === k.OBCIRadioBaudRateFastStr) {
-        this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdBaudRateSetFast]));
+        this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdBaudRateSetFast])).catch(reject);
       } else {
-        this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdBaudRateSetDefault]));
+        this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdBaudRateSetDefault])).catch(reject);
       }
     });
   };
@@ -970,7 +980,7 @@ function OpenBCIFactory () {
       this.curParsingMode = k.OBCIParsingEOT;
 
       // Send the radio channel query command
-      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdSystemStatus]));
+      this._writeAndDrain(new Buffer([k.OBCIRadioKey, k.OBCIRadioCmdSystemStatus])).catch(reject);
     });
   };
 
@@ -1095,10 +1105,8 @@ function OpenBCIFactory () {
         .then((val) => {
           arrayOfCommands = val.commandArray;
           this.channelSettingsArray[channelNumber - 1] = val.newChannelSettingsObject;
-          resolve(this.write(arrayOfCommands));
-        }, function (err) {
-          reject(err);
-        });
+          return this.write(arrayOfCommands);
+        }).then(resolve, reject);
     });
   };
 
@@ -1146,12 +1154,13 @@ function OpenBCIFactory () {
       this.impedanceTest.active = true;
       this.impedanceTest.continuousMode = true;
 
+      var chain = Promise.resolve();
       for (var i = 0; i < this.numberOfChannels(); i++) {
-        k.getImpedanceSetter(i + 1, false, true).then((commandsArray) => {
-          this.write(commandsArray);
-        });
+        chain = chain
+          .then(() => k.getImpedanceSetter(i + 1, false, true))
+          .then((commandsArray) => this.write(commandsArray));
       }
-      resolve();
+      chain.then(resolve, reject);
     });
   };
 
@@ -1168,12 +1177,13 @@ function OpenBCIFactory () {
       this.impedanceTest.active = false;
       this.impedanceTest.continuousMode = false;
 
+      var chain = Promise.resolve();
       for (var i = 0; i < this.numberOfChannels(); i++) {
-        k.getImpedanceSetter(i + 1, false, false).then((commandsArray) => {
-          this.write(commandsArray);
-        });
+        chain = chain
+          .then(() => k.getImpedanceSetter(i + 1, false, false))
+          .then((commandsArray) => this.write(commandsArray));
       }
-      resolve();
+      chain.then(resolve, reject);
     });
   };
 
@@ -1358,8 +1368,6 @@ function OpenBCIFactory () {
     return new Promise((resolve, reject) => {
       if (!this.isConnected()) return reject('Must be connected');
 
-      var delayInMS = 0;
-
       /* istanbul ignore if */
       if (this.options.verbose) {
         if (pInput && !nInput) {
@@ -1382,18 +1390,15 @@ function OpenBCIFactory () {
       if (this.options.verbose) console.log('pInput: ' + pInput + ' nInput: ' + nInput);
       // Get impedance settings to send the board
       k.getImpedanceSetter(channelNumber, pInput, nInput).then((commandsArray) => {
-        this.write(commandsArray);
-        // delayInMS += commandsArray.length * k.OBCIWriteIntervalDelayMSLong
-        delayInMS += this.commandsToWrite * k.OBCIWriteIntervalDelayMSShort; // Account for commands waiting to be sent in the write buffer
-        setTimeout(() => {
-          /**
-          * If either pInput or nInput are true then we should start calculating impedance. Setting
-          *  this.impedanceTest.active to true here allows us to route every sample for an impedance
-          *  calculation instead of the normal sample output.
-          */
-          if (pInput || nInput) this.impedanceTest.active = true;
-          resolve(channelNumber);
-        }, delayInMS); // Prevents emitting .impedanceArray before all setting commands have been applied
+        return this.write(commandsArray);
+      }).then(() => {
+        /**
+        * If either pInput or nInput are true then we should start calculating impedance. Setting
+        *  this.impedanceTest.active to true here allows us to route every sample for an impedance
+        *  calculation instead of the normal sample output.
+        */
+        if (pInput || nInput) this.impedanceTest.active = true;
+        resolve(channelNumber);
       }, (err) => {
         reject(err);
       });
@@ -1494,7 +1499,7 @@ function OpenBCIFactory () {
   *      response from the board.
   * @param recordingDuration {String} - The duration you want to log SD information for. Limited to:
   *      '14sec', '5min', '15min', '30min', '1hour', '2hour', '4hour', '12hour', '24hour'
-  * @returns {Promise} - Resolves if the command was added to write queue.
+  * @returns {Promise} - Resolves when the command has been written.
   * @private
   * @author AJ Keller (@pushtheworldllc)
   */
@@ -1517,7 +1522,7 @@ function OpenBCIFactory () {
   /**
   * @description Sends the stop SD logging command to the board. If not streaming then `eot` event will be emitted
   *      with request response from the board.
-  * @returns {Promise} - Resovles if added to the write queue
+  * @returns {Promise} - Resolves when written
   * @author AJ Keller (@pushtheworldllc)
   */
   OpenBCIBoard.prototype.sdStop = function () {
@@ -1593,8 +1598,7 @@ function OpenBCIFactory () {
       this.sync.curSyncObj = openBCISample.newSyncObject();
       this.sync.curSyncObj.timeSyncSent = this.time();
       this.curParsingMode = k.OBCIParsingTimeSyncSent;
-      this._writeAndDrain(k.OBCISyncTimeSet);
-      resolve();
+      this._writeAndDrain(k.OBCISyncTimeSet).then(resolve, reject);
     });
   };
 

--- a/openBCIConstants.js
+++ b/openBCIConstants.js
@@ -926,7 +926,10 @@ module.exports = {
 *                     false -> Disconnect all N inputs from SRB1 (default))
 *          Select to connect (true) all channels' N inputs to SRB1. This effects all pins,
 *              and disconnects all N inputs from the ADC.
-* @returns {Promise} resolves array of commands to be sent, rejects on bad input or no board
+* @returns {Promise} resolves {commandArray: array of commands to be sent,
+                               newChannelSettingsObject: an updated channel settings object
+                                                         to be stored in openBCIBoard.channelSettingsArray},
+                     rejects on bad input or no board
 */
 function channelSetter (channelNumber, powerDown, gain, inputType, bias, srb2, srb1) {
   // Used to store and assemble the commands
@@ -991,8 +994,7 @@ function channelSetter (channelNumber, powerDown, gain, inputType, bias, srb2, s
         cmdSrb1,
         obciChannelCmdLatch
       ];
-      // console.log(outputArray)
-      resolve(outputArray, newChannelSettingsObject);
+      resolve({commandArray: outputArray, newChannelSettingsObject: newChannelSettingsObject});
     });
   });
 }

--- a/openBCISample.js
+++ b/openBCISample.js
@@ -522,6 +522,7 @@ var sampleModule = {
   makeTailByteFromPacketType,
   isStopByte,
   newSyncObject,
+  stripToEOTBuffer,
   /**
   * @description Checks to make sure the previous sample number is one less
   *  then the new sample number. Takes into account sample numbers wrapping
@@ -1109,6 +1110,31 @@ function isSuccessInBuffer (dataBuffer) {
 
   // Check and see if there is a match
   return s.matches >= 1;
+}
+
+/**
+ * @description Used to slice a buffer for the EOT '$$$'.
+ * @param dataBuffer {Buffer} - The buffer of some length to parse
+ * @returns {Buffer} - The remaining buffer.
+ */
+function stripToEOTBuffer (dataBuffer) {
+  let indexOfEOT = dataBuffer.indexOf(k.OBCIParseEOT);
+  if (indexOfEOT > 0) {
+    indexOfEOT += k.OBCIParseEOT.length;
+  } else {
+    return dataBuffer;
+  }
+
+  if (indexOfEOT < dataBuffer.byteLength) {
+    if (k.getVersionNumber(process.version) >= 6) {
+      // From introduced in node version 6.x.x
+      return Buffer.from(dataBuffer.slice(indexOfEOT));
+    } else {
+      return new Buffer(dataBuffer.slice(indexOfEOT));
+    }
+  } else {
+    return null;
+  }
 }
 
 /**

--- a/openBCISimulator.js
+++ b/openBCISimulator.js
@@ -101,11 +101,13 @@ function OpenBCISimulatorFactory () {
   // TODO: upgrade from old-style streams to stream.Duplex or stream.Transform
   util.inherits(OpenBCISimulator, stream.Stream);
 
-  OpenBCISimulator.prototype.flush = function () {
+  OpenBCISimulator.prototype.flush = function (callback) {
     this.outputBuffered = 0;
 
     clearTimeout(this.outputLoopHandle);
     this.outputLoopHandle = null;
+
+    if (callback) callback();
   };
 
   OpenBCISimulator.prototype.isOpen = function () {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci",
-  "version": "1.4.0",
+  "version": "1.4.1",
   "description": "The official Node.js SDK for the OpenBCI Biosensor Board.",
   "main": "openBCIBoard",
   "scripts": {

--- a/test/OpenBCIConstants-test.js
+++ b/test/OpenBCIConstants-test.js
@@ -792,32 +792,60 @@ describe('OpenBCIConstants', function () {
     describe('channel input selection works', function () {
       // this.timeout(5000)
       it('channel 2', function (done) {
-        k.getChannelSetter(2, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[1].should.equal('2');
+        k.getChannelSetter(2, false, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[1].should.equal('2');
+          val.newChannelSettingsObject.channelNumber.should.equal(2);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('channel 5', function (done) {
-        k.getChannelSetter(5, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[1].should.equal('5');
+        k.getChannelSetter(5, false, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[1].should.equal('5');
+          val.newChannelSettingsObject.channelNumber.should.equal(5);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('channel 9', function (done) {
-        k.getChannelSetter(9, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[1].should.equal('Q');
+        k.getChannelSetter(9, false, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[1].should.equal('Q');
+          val.newChannelSettingsObject.channelNumber.should.equal(9);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('channel 15', function (done) {
-        k.getChannelSetter(15, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[1].should.equal('U');
+        k.getChannelSetter(15, false, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[1].should.equal('U');
+          val.newChannelSettingsObject.channelNumber.should.equal(15);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
@@ -832,16 +860,30 @@ describe('OpenBCIConstants', function () {
     });
     describe('power selection works', function () {
       it('on', function (done) {
-        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[2].should.equal('0');
+        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[2].should.equal('0');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('off', function (done) {
-        k.getChannelSetter(1, true, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[2].should.equal('1');
+        k.getChannelSetter(1, true, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[2].should.equal('1');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(true);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
@@ -853,56 +895,105 @@ describe('OpenBCIConstants', function () {
     });
     describe('gain selection works', function () {
       it('1x', function (done) {
-        k.getChannelSetter(1, false, 1, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[3].should.equal('0');
+        k.getChannelSetter(1, false, 1, 'normal', true, true, false).then(function (val) {
+          val.commandArray[3].should.equal('0');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(1);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('2x', function (done) {
-        k.getChannelSetter(1, false, 2, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[3].should.equal('1');
+        k.getChannelSetter(1, false, 2, 'normal', true, true, false).then(function (val) {
+          val.commandArray[3].should.equal('1');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(2);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('4x', function (done) {
-        k.getChannelSetter(1, false, 4, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[3].should.equal('2');
+        k.getChannelSetter(1, false, 4, 'normal', true, true, false).then(function (val) {
+          val.commandArray[3].should.equal('2');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(4);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('6x', function (done) {
-        k.getChannelSetter(1, false, 6, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[3].should.equal('3');
+        k.getChannelSetter(1, false, 6, 'normal', true, true, false).then(function (val) {
+          val.commandArray[3].should.equal('3');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(6);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('8x', function (done) {
-        k.getChannelSetter(1, false, 8, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[3].should.equal('4');
+        k.getChannelSetter(1, false, 8, 'normal', true, true, false).then(function (val) {
+          val.commandArray[3].should.equal('4');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(8);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('12x', function (done) {
-        k.getChannelSetter(1, false, 12, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[3].should.equal('5');
+        k.getChannelSetter(1, false, 12, 'normal', true, true, false).then(function (val) {
+          val.commandArray[3].should.equal('5');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(12);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('24x', function (done) {
-        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[3].should.equal('6');
+        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[3].should.equal('6');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
@@ -917,64 +1008,120 @@ describe('OpenBCIConstants', function () {
     });
     describe('input type', function () {
       it('normal', function (done) {
-        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[4].should.equal('0');
+        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[4].should.equal('0');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('shorted', function (done) {
-        k.getChannelSetter(1, false, 24, 'shorted', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[4].should.equal('1');
+        k.getChannelSetter(1, false, 24, 'shorted', true, true, false).then(function (val) {
+          val.commandArray[4].should.equal('1');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('shorted');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('biasMethod', function (done) {
-        k.getChannelSetter(1, false, 24, 'biasMethod', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[4].should.equal('2');
+        k.getChannelSetter(1, false, 24, 'biasMethod', true, true, false).then(function (val) {
+          val.commandArray[4].should.equal('2');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('biasMethod');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('mvdd', function (done) {
-        k.getChannelSetter(1, false, 24, 'mvdd', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[4].should.equal('3');
+        k.getChannelSetter(1, false, 24, 'mvdd', true, true, false).then(function (val) {
+          val.commandArray[4].should.equal('3');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('mvdd');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('temp', function (done) {
-        k.getChannelSetter(1, false, 24, 'temp', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[4].should.equal('4');
+        k.getChannelSetter(1, false, 24, 'temp', true, true, false).then(function (val) {
+          val.commandArray[4].should.equal('4');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('temp');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('testsig', function (done) {
-        k.getChannelSetter(1, false, 24, 'testSig', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[4].should.equal('5');
+        k.getChannelSetter(1, false, 24, 'testSig', true, true, false).then(function (val) {
+          val.commandArray[4].should.equal('5');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('testSig');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('biasDrp', function (done) {
-        k.getChannelSetter(1, false, 24, 'biasDrp', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[4].should.equal('6');
+        k.getChannelSetter(1, false, 24, 'biasDrp', true, true, false).then(function (val) {
+          val.commandArray[4].should.equal('6');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('biasDrp');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('biasDrn', function (done) {
-        k.getChannelSetter(1, false, 24, 'biasDrn', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[4].should.equal('7');
+        k.getChannelSetter(1, false, 24, 'biasDrn', true, true, false).then(function (val) {
+          val.commandArray[4].should.equal('7');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('biasDrn');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
@@ -989,16 +1136,30 @@ describe('OpenBCIConstants', function () {
     });
     describe('bias selection works', function () {
       it('Include', function (done) {
-        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[5].should.equal('1');
+        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[5].should.equal('1');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('Remove', function (done) {
-        k.getChannelSetter(1, false, 24, 'normal', false, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[5].should.equal('0');
+        k.getChannelSetter(1, false, 24, 'normal', false, true, false).then(function (val) {
+          val.commandArray[5].should.equal('0');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(false);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
@@ -1010,16 +1171,30 @@ describe('OpenBCIConstants', function () {
     });
     describe('SRB2 selection works', function () {
       it('Connect', function (done) {
-        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[6].should.equal('1');
+        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[6].should.equal('1');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('Disconnect', function (done) {
-        k.getChannelSetter(1, false, 24, 'normal', true, false, false).then(function (arrayOfCommands) {
-          arrayOfCommands[6].should.equal('0');
+        k.getChannelSetter(1, false, 24, 'normal', true, false, false).then(function (val) {
+          val.commandArray[6].should.equal('0');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(false);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);
@@ -1031,16 +1206,30 @@ describe('OpenBCIConstants', function () {
     });
     describe('SRB1 selection works', function () {
       it('Connect', function (done) {
-        k.getChannelSetter(1, false, 24, 'normal', true, true, true).then(function (arrayOfCommands) {
-          arrayOfCommands[7].should.equal('1');
+        k.getChannelSetter(1, false, 24, 'normal', true, true, true).then(function (val) {
+          val.commandArray[7].should.equal('1');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(true);
           done();
         }).catch(function (err) {
           done(err);
         });
       });
       it('Disconnect', function (done) {
-        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (arrayOfCommands) {
-          arrayOfCommands[7].should.equal('0');
+        k.getChannelSetter(1, false, 24, 'normal', true, true, false).then(function (val) {
+          val.commandArray[7].should.equal('0');
+          val.newChannelSettingsObject.channelNumber.should.equal(1);
+          val.newChannelSettingsObject.powerDown.should.equal(false);
+          val.newChannelSettingsObject.gain.should.equal(24);
+          val.newChannelSettingsObject.inputType.should.equal('normal');
+          val.newChannelSettingsObject.bias.should.equal(true);
+          val.newChannelSettingsObject.srb2.should.equal(true);
+          val.newChannelSettingsObject.srb1.should.equal(false);
           done();
         }).catch(function (err) {
           done(err);

--- a/test/OpenBCISample-test.js
+++ b/test/OpenBCISample-test.js
@@ -1210,6 +1210,51 @@ $$$`);
       expect(openBCISample.droppedPacketCheck(previous, current)).to.be.null;
     });
   });
+  describe('#stripToEOTBuffer', function () {
+    it('should return the buffer if no EOT', function () {
+      let buf = null;
+      if (k.getVersionNumber(process.version) >= 6) {
+        // From introduced in node version 6.x.x
+        buf = Buffer.from('tacos are delicious');
+      } else {
+        buf = new Buffer('tacos are delicious');
+      }
+      expect(openBCISample.stripToEOTBuffer(buf).toString()).to.equal(buf.toString());
+    });
+    it('should slice the buffer after eot $$$', function () {
+      let bufPre = null;
+      let eotBuf = null;
+      let bufPost = null;
+      if (k.getVersionNumber(process.version) >= 6) {
+        // From introduced in node version 6.x.x
+        bufPre = Buffer.from('tacos are delicious');
+        eotBuf = Buffer.from(k.OBCIParseEOT);
+        bufPost = Buffer.from('tacos');
+      } else {
+        bufPre = new Buffer('tacos are delicious');
+        eotBuf = new Buffer(k.OBCIParseEOT);
+        bufPost = new Buffer('tacos');
+      }
+
+      let totalBuf = Buffer.concat([bufPre, eotBuf, bufPost]);
+      expect(openBCISample.stripToEOTBuffer(totalBuf).toString()).to.equal(bufPost.toString());
+    });
+    it('should return null if nothing left', function () {
+      let bufPre = null;
+      let eotBuf = null;
+      if (k.getVersionNumber(process.version) >= 6) {
+        // From introduced in node version 6.x.x
+        bufPre = Buffer.from('tacos are delicious');
+        eotBuf = Buffer.from(k.OBCIParseEOT);
+      } else {
+        bufPre = new Buffer('tacos are delicious');
+        eotBuf = new Buffer(k.OBCIParseEOT);
+      }
+
+      let totalBuf = Buffer.concat([bufPre, eotBuf]);
+      expect(openBCISample.stripToEOTBuffer(totalBuf)).to.equal(null);
+    });
+  });
 });
 
 describe('#goertzelProcessSample', function () {

--- a/test/openBCIBoard-test.js
+++ b/test/openBCIBoard-test.js
@@ -245,34 +245,18 @@ describe('openbci-sdk', function () {
       expect(ourBoard2.options.simulatorSerialPortFailure).to.be.true;
     });
     it('should be able to enter sync mode', function () {
-      var ourBoard1, ourBoard2;
-
-      ourBoard1 = new openBCIBoard.OpenBCIBoard({
+      var ourBoard = new openBCIBoard.OpenBCIBoard({
         sntpTimeSync: true
       });
-      expect(ourBoard1.options.sntpTimeSync).to.be.true;
+      expect(ourBoard.options.sntpTimeSync).to.be.true;
 
-      // Verify multi case support
-      ourBoard2 = new openBCIBoard.OpenBCIBoard({
-        sntptimesync: true
-      });
-      expect(ourBoard2.options.sntpTimeSync).to.be.true;
-
-      return Promise.all([
-        new Promise((resolve, reject) => {
-          ourBoard1.once('sntpTimeLock', resolve);
-          ourBoard1.once('error', reject);
-        }),
-        new Promise((resolve, reject) => {
-          ourBoard2.once('sntpTimeLock', resolve);
-          ourBoard2.once('error', reject);
-        })
-      ]).then(() => {
-        ourBoard1.sntpStop();
-        ourBoard2.sntpStop();
+      return new Promise((resolve, reject) => {
+        ourBoard.once('sntpTimeLock', resolve);
+        ourBoard.once('error', reject);
+      }).then(() => {
+        ourBoard.sntpStop();
       }, err => {
-        ourBoard1.sntpStop();
-        ourBoard2.sntpStop();
+        ourBoard.sntpStop();
         return Promise.reject(err);
       });
     });

--- a/test/openBCIBoard-test.js
+++ b/test/openBCIBoard-test.js
@@ -509,6 +509,9 @@ describe('openbci-sdk', function () {
       if (spy) spy.reset();
     });
     describe('#connect/disconnect/streamStart/streamStop', function () {
+      it('rejects if already disconnected', function () {
+        return ourBoard.disconnect().should.be.rejected;
+      });
       it('rejects if already connected', function (done) {
         ourBoard.connect(masterPortName).catch(err => done(err));
 
@@ -598,7 +601,7 @@ describe('openbci-sdk', function () {
       });
       afterEach(function (done) {
         if (ourBoard.isConnected()) {
-          ourBoard.disconnect().then(done, () => done());
+          ourBoard.disconnect().then(done, done);
         } else {
           done();
         }
@@ -624,12 +627,10 @@ describe('openbci-sdk', function () {
         var writeSpy1 = sinon.spy(ourBoard.serial, 'write');
         var byteToWrite = k.OBCISDLogStop;
         var writeWhileConnected = function () {
-          var commands = [];
-          while (commands.length < 4) commands.push(byteToWrite);
-          ourBoard.write(commands).then(() => {
+          ourBoard.write(byteToWrite).then(() => {
             if (ourBoard.isConnected()) {
               writeSpy1.reset();
-              setTimeout(writeWhileConnected, 10 * (commands.length - 1));
+              writeWhileConnected();
             } else {
               done('wrote when not connected');
             }
@@ -637,15 +638,17 @@ describe('openbci-sdk', function () {
             if (ourBoard.isConnected()) {
               done(err);
             } else {
-              ourBoard.connect(masterPortName).catch(done);
-              var writeSpy2 = sinon.spy(ourBoard.serial, 'write');
-              ourBoard.once('ready', () => {
-                writeSpy2.should.equal(ourBoard.serial.write);
-                writeSpy1.should.have.not.been.called;
-                writeSpy2.should.have.not.been.calledWith(byteToWrite);
-                writeSpy1.restore();
-                writeSpy2.restore();
-                done();
+              process.nextTick(() => {
+                ourBoard.connect(masterPortName).catch(done);
+                var writeSpy2 = sinon.spy(ourBoard.serial, 'write');
+                ourBoard.once('ready', () => {
+                  writeSpy2.should.equal(ourBoard.serial.write);
+                  writeSpy1.should.have.not.been.called;
+                  writeSpy2.should.have.not.been.calledWith(byteToWrite);
+                  writeSpy1.restore();
+                  writeSpy2.restore();
+                  done();
+                });
               });
             }
           });
@@ -653,13 +656,17 @@ describe('openbci-sdk', function () {
         writeWhileConnected();
         ourBoard.disconnect().catch(done);
       });
-      it('disconnects immediately without performing buffered writes', function (done) {
+      it('disconnects immediately, rejecting all buffered writes', function () {
         var writeSpy = sinon.spy(ourBoard.serial, 'write');
-        ourBoard.write(k.OBCISDLogStop);
-        ourBoard.disconnect().then(() => {
+        return Promise.all([
+          ourBoard.write(k.OBCISDLogStop).should.have.been.rejected,
+          ourBoard.write(k.OBCISDLogStop).should.have.been.rejected,
+          ourBoard.write(k.OBCISDLogStop).should.have.been.rejected,
+          ourBoard.write(k.OBCISDLogStop).should.have.been.rejected,
+          ourBoard.disconnect()
+        ]).then(() => {+
           writeSpy.should.have.not.been.called;
           writeSpy.restore();
-          done();
         });
       });
     });

--- a/test/openBCISimulator-test.js
+++ b/test/openBCISimulator-test.js
@@ -667,7 +667,7 @@ describe('openBCISimulator', function () {
         bufferSize: bufferSize,
         latencyTime: 1000
       });
-      simulator.on('data', function (buffer) {
+      simulator.once('data', function (buffer) {
         expect(buffer.length).to.equal(bufferSize);
         done();
       });


### PR DESCRIPTION
# 1.4.1

### Bug Fixes
* Fixes bug where extra data after EOT (`$$$`) was dumped by preserving the poriton after the EOT for further decomposition.
* Fixes bug where any calls to channel set would actually break the openBCISample code as the channelSettingsArray contained an undefined.