### PR TITLE
Fix 16 chan

### DIFF
--- a/README.md
+++ b/README.md
@@ -847,7 +847,7 @@ Stop logging to the SD card and close any open file. If you are not streaming wh
 
 **_Returns_** resolves if the command was added to the write queue.
 
-### <a name="method-set-info-for-board-type"></a> .setInfoForBoardType(boardType)
+### <a name="method-set-info-for-board-type"></a> .overrideInfoForBoardType(boardType)
 
 Set the info property for board type. 
 

--- a/README.md
+++ b/README.md
@@ -73,7 +73,7 @@ Want to know if the module really works? Check out some projects and organizatio
 
 Still not satisfied it works?? Check out this [detailed report](http://s132342840.onlinehome.us/pushtheworld/files/voltageVerificationTestPlanAndResults.pdf) that scientifically validates the output voltages of this module.
 
-How are you still doubting and not using this already? Fine, go look at some of the [700 **_automatic_** tests](https://codecov.io/gh/OpenBCI/OpenBCI_NodeJS) written for it!
+How are you still doubting and not using this already? Fine, go look at some of the [800 **_automatic_** tests](https://codecov.io/gh/OpenBCI/OpenBCI_NodeJS) written for it!
 
 Python researcher or developer? Check out how easy it is to [get access to the entire API in the Python example](examples/python)!
 
@@ -88,6 +88,7 @@ Initializing the board:
 var OpenBCIBoard = require('openbci');
 var ourBoard = new OpenBCIBoard.OpenBCIBoard();
 ```
+Go [checkout out the get streaming example](examples/getStreaming/getStreaming.js)!
 
 For initializing with options, such as verbose print outs:
 
@@ -106,6 +107,16 @@ var ourBoard = new OpenBCIBoard({
     simulate: true
 });
 ```
+
+Have a daisy?:
+```js
+var OpenBCIBoard = require('openbci').OpenBCIBoard;
+var ourBoard = new OpenBCIBoard({
+    boardType: `daisy`,
+    hardSet: true
+});
+```
+Go [checkout out the get streaming with daisy example](examples/getStreamingDaisy/getStreamingDaisy.js)!
 
 Another useful way to start the simulator:
 ```js
@@ -130,7 +141,7 @@ var ourBoard = new OpenBCIBoard({
     simulate: true
 });
 ```
-ps: go [checkout out the example](examples/debug/debug.js) to do it right now!
+Go [checkout out the debug example](examples/debug/debug.js)!
 
 'ready' event
 ------------
@@ -395,6 +406,7 @@ Board optional configurations.
   * `daisy` - 8 Channel board with Daisy Module - 16 Channels
   * `ganglion` - 4 Channel board
     (NOTE: THIS IS IN-OP TIL RELEASE OF GANGLION BOARD 08/2016)
+* `hardSet` {Boolean} - Recommended if using `daisy` board! For some reason, the `daisy` is sometimes not picked up by the module so you can set `hardSet` to true which will ensure the daisy is picked up. (Default `false`)
 * `simulate` {Boolean} - Full functionality, just mock data. Must attach Daisy module by setting `simulatorDaisyModuleAttached` to `true` in order to get 16 channels. (Default `false`)
 * `simulatorBoardFailure` {Boolean} - Simulates board communications failure. This occurs when the RFduino on the board is not polling the RFduino on the dongle. (Default `false`)
 * `simulatorDaisyModuleAttached` {Boolean} - Simulates a daisy module being attached to the OpenBCI board. This is useful if you want to test how your application reacts to a user requesting 16 channels but there is no daisy module actually attached, or vice versa, where there is a daisy module attached and the user only wants to use 8 channels. (Default `false`)
@@ -531,6 +543,21 @@ A number specifying which channel you want to get data on. Only 1-8 at this time
 **Note, at this time this does not work for the daisy board**
 
 **_Returns_** a promise, fulfilled if the command was sent to the board and the `.processBytes()` function is ready to reach for the specified channel.
+
+### <a name="method-hard-set-board-type"></a> .hardSetBoardType(boardType)
+
+Used to sync the module and board to `boardType`.
+
+**Note: This has the potential to change the way data is parsed** 
+ 
+**_boardType_**
+
+A String indicating the number of channels.
+
+* `default` - Default board: Sample rate is `250Hz` and number of channels is `8`. 
+* `daisy` - Daisy board: Sample rate is `125Hz` and number of channels is `16`.
+
+**_Returns_** a promise, fulfilled if both the board and module are the requested `boardType`, rejects otherwise.
 
 ### <a name="method-impedance-test-all-channels"></a> .impedanceTestAllChannels()
 
@@ -721,6 +748,19 @@ Get the current number of channels available to use. (i.e. 8 or 16).
 
 **_Returns_** a number, the total number of available channels.
 
+### <a name="method-override-info-for-board-type"></a> .overrideInfoForBoardType(boardType)
+
+Set the info property for board type. 
+
+**Note: This has the potential to change the way data is parsed** 
+ 
+**_boardType_**
+
+A String indicating the number of channels.
+
+* `default` - Default board: Sample rate is `250Hz` and number of channels is `8`. 
+* `daisy` - Daisy board: Sample rate is `125Hz` and number of channels is `16`.
+
 ### <a name="method-print-bytes-in"></a> .printBytesIn()
 
 Prints the total number of bytes that were read in this session to the console.
@@ -846,34 +886,6 @@ The duration you want to log SD information for. Opens a new SD file to write in
 Stop logging to the SD card and close any open file. If you are not streaming when you send this command, then you should expect to get a success or failure message followed by and end of transmission `$$$`. The success message contains a lot of useful information about what happened when writing to the SD card.
 
 **_Returns_** resolves if the command was added to the write queue.
-
-### <a name="method-set-info-for-board-type"></a> .overrideInfoForBoardType(boardType)
-
-Set the info property for board type. 
-
-**Note: This has the potential to change the way data is parsed** 
- 
-**_boardType_**
-
-A String indicating the number of channels.
-
-* `default` - Default board: Sample rate is `250Hz` and number of channels is `8`. 
-* `daisy` - Daisy board: Sample rate is `125Hz` and number of channels is `16`.
-
-**_Returns_** a promise, fulfilled if the command was sent to the write queue. Rejects if input is not `8` or `16`.
-
-### <a name="method-set-max-channels"></a> .setMaxChannels(numberOfChannels)
-
-Sends a command to the board to set the max channels. If you have a daisy attached, calling this function will re-sniff for the daisy ADS and attempt to use it.
- 
-**_numberOfChannels_**
-
-A Number indicating the number of channels.
-
-* `8` - Default number of channels.
-* `16` - Daisy number of channels.
-
-**_Returns_** a promise, fulfilled if the command was sent to the write queue. Rejects if input is not `8` or `16`.
 
 ### <a name="method-simulator-enable"></a> .simulatorEnable()
 
@@ -1113,6 +1125,10 @@ Emitted when a packet (or packets) are dropped. Returns an array.
 ### <a name="event-error"></a> .on('error', callback)
 
 Emitted when there is an on the serial port.
+
+### <a name="event-hard-set"></a> .on('hardSet', callback)
+
+Emitted when the module detects the board is not configured as the options for the module intended and tries to save itself. i.e. when the `daisy` option is `true` and a soft reset message is parsed and the module determines that a daisy was not detected, the module will emit `hardSet` then send an attach daisy command to recover. Either `error` will be emitted if unable to attach or `ready` will be emitted if success.
 
 ### <a name="event-impedance-array"></a> .on('impedanceArray', callback)
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,9 +1,21 @@
+# 1.5.0
+
+### New Features
+* New simulator option `simulatorDaisyModuleCanBeAttached` - Boolean, deafults to true, allows the simulation of the a hot swapped daisy board or simulates a misinformed module.
+
+### Bug Fixes
+* Fixes #131 - 16 chan not working by sending a channel command and parsing the return.
+* Fixed bug where end of transmission characters would not be ejected from buffer.
+
+### Breaking changes
+* `.overrideInfoForBoardType()` changed to `.overrideInfoForBoardType()` to elevate it's dangerous nature.
+ 
 # 1.4.4
 
 ### New Features
 * Set max number of channels for the board to use with `.setMaxChannels()` see readme.md
-* Set the core info object that drives the module with `.setInfoForBoardType()` see readme.md
-* Get info for the core obhect that drives the module with `.getInfo()` see readme.md
+* Set the core info object that drives the module with `.overrideInfoForBoardType()` see readme.md
+* Get info for the core object that drives the module with `.getInfo()` see readme.md
 
 ### Work In Progress
 * Bug where daisy would sometimes not be recognized which destroyed all data.

--- a/changelog.md
+++ b/changelog.md
@@ -2,13 +2,18 @@
 
 ### New Features
 * New simulator option `simulatorDaisyModuleCanBeAttached` - Boolean, deafults to true, allows the simulation of the a hot swapped daisy board or simulates a misinformed module.
+* New `EventEmitter` - `hardSet` - for when the module detects the board is not configured as the options for the module intended and tries to save itself. i.e. when the `daisy` option is `true` and a soft reset message is parsed and the module determines that a daisy was not detected, the module will emit `hardSet` then send an attach daisy command to recover. Either `error` will be emitted if unable to attach or `ready` will be emitted if success.
+
+### Breaking changes
+* `.setInfoForBoardType()` changed to `.overrideInfoForBoardType()` to elevate it's dangerous nature.
+* `.setMaxChannels()` changed to `.hardSetBoardType()` and input changed from numerical to string: 8 and 16 to `default` and `daisy` respectively.
 
 ### Bug Fixes
 * Fixes #131 - 16 chan not working by sending a channel command and parsing the return.
 * Fixed bug where end of transmission characters would not be ejected from buffer.
-
-### Breaking changes
-* `.overrideInfoForBoardType()` changed to `.overrideInfoForBoardType()` to elevate it's dangerous nature.
+ 
+### Enhancements
+* Separated radio tests from main board test file.
  
 # 1.4.4
 

--- a/changelog.md
+++ b/changelog.md
@@ -3,6 +3,7 @@
 ### New Features
 * New simulator option `simulatorDaisyModuleCanBeAttached` - Boolean, deafults to true, allows the simulation of the a hot swapped daisy board or simulates a misinformed module.
 * New `EventEmitter` - `hardSet` - for when the module detects the board is not configured as the options for the module intended and tries to save itself. i.e. when the `daisy` option is `true` and a soft reset message is parsed and the module determines that a daisy was not detected, the module will emit `hardSet` then send an attach daisy command to recover. Either `error` will be emitted if unable to attach or `ready` will be emitted if success.
+* Add example for streaming with `daisy` and `hardSet`.
 
 ### Breaking changes
 * `.setInfoForBoardType()` changed to `.overrideInfoForBoardType()` to elevate it's dangerous nature.

--- a/examples/getStreamingDaisy/getStreamingDaisy.js
+++ b/examples/getStreamingDaisy/getStreamingDaisy.js
@@ -1,0 +1,93 @@
+/**
+ * This is an example from the readme.md
+ * On windows you should run with PowerShell not git bash.
+ * Install
+ *   [nodejs](https://nodejs.org/en/)
+ *
+ * To run:
+ *   change directory to this file `cd examples/debug`
+ *   do `npm install`
+ *   then `npm start`
+ */
+var debug = false; // Pretty print any bytes in and out... it's amazing...
+var verbose = true; // Adds verbosity to functions
+
+var OpenBCIBoard = require('openbci').OpenBCIBoard;
+var ourBoard = new OpenBCIBoard({
+  boardType: 'daisy',
+  debug: debug,
+  hardSet: true,
+  verbose: verbose
+});
+
+ourBoard.on('error', (err) => {
+  console.log(err);
+});
+
+ourBoard.autoFindOpenBCIBoard().then(portName => {
+  if (portName) {
+    /**
+     * Connect to the board with portName
+     * Only works if one board is plugged in
+     * i.e. ourBoard.connect(portName).....
+     */
+    ourBoard.connect(portName) // Port name is a serial port name, see `.listPorts()`
+      .then(() => {
+        ourBoard.once('ready',() => {
+          ourBoard.streamStart();
+          ourBoard.on('sample',(sample) => {
+            /** Work with sample */
+            for (var i = 0; i < ourBoard.numberOfChannels(); i++) {
+              console.log("Channel " + (i + 1) + ": " + sample.channelData[i].toFixed(8) + " Volts.");
+              // prints to the console
+              //  "Channel 1: 0.00001987 Volts."
+              //  "Channel 2: 0.00002255 Volts."
+              //  ...
+              //  "Channel 16: -0.00001875 Volts."
+            }
+          });
+        });
+      });
+  } else {
+    /** Unable to auto find OpenBCI board */
+    console.log('Unable to auto find OpenBCI board');
+  }
+});
+
+function exitHandler (options, err) {
+  if (options.cleanup) {
+    if (verbose) console.log('clean');
+    /** Do additional clean up here */
+  }
+  if (err) console.log(err.stack);
+  if (options.exit) {
+    if (verbose) console.log('exit');
+    ourBoard.disconnect().catch(console.log);
+  }
+}
+
+if (process.platform === "win32") {
+  const rl = require("readline").createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  rl.on("SIGINT", function () {
+    process.emit("SIGINT");
+  });
+}
+
+// do something when app is closing
+process.on('exit', exitHandler.bind(null, {
+  cleanup: true
+}));
+
+// catches ctrl+c event
+process.on('SIGINT', exitHandler.bind(null, {
+  exit: true
+}));
+
+// catches uncaught exceptions
+process.on('uncaughtException', exitHandler.bind(null, {
+  exit: true
+}));

--- a/examples/getStreamingDaisy/package.json
+++ b/examples/getStreamingDaisy/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "get-streaming-daisy",
+  "version": "1.0.0",
+  "description": "Get streaming with hard set daisy example",
+  "main": "getStreaming.js",
+  "scripts": {
+    "start": "node getStreamingDaisy.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "get"
+  ],
+  "author": "AJ Keller",
+  "license": "MIT",
+  "dependencies": {
+    "openbci": "^1.5.0"
+  }
+}

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -1088,10 +1088,6 @@ function OpenBCIFactory () {
     return new Promise((resolve, reject) => {
       const eotFunc = (data) => {
         switch (data.slice(0, data.length - k.OBCIParseEOT.length).toString()) {
-          case k.OBCIChannelMaxNumber8NoDaisyToRemove:
-            this.overrideInfoForBoardType(k.OBCIBoardDefault);
-            resolve('no daisy to remove');
-            break;
           case k.OBCIChannelMaxNumber8SuccessDaisyRemoved:
             this.overrideInfoForBoardType(k.OBCIBoardDefault);
             resolve('daisy removed');
@@ -1108,8 +1104,10 @@ function OpenBCIFactory () {
             this.overrideInfoForBoardType(k.OBCIBoardDefault);
             reject('unable to attach daisy');
             break;
+          case k.OBCIChannelMaxNumber8NoDaisyToRemove:
           default:
-            reject(Error('invalid return, board may not be configured correctly.'));
+            this.overrideInfoForBoardType(k.OBCIBoardDefault);
+            resolve('no daisy to remove');
             break;
         }
       };

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -1078,7 +1078,7 @@ function OpenBCIFactory () {
   };
 
   /**
-   * Used to set the max number of channels on the Cyton board.
+   * Used to sync the module and board to `boardType`
    * @param boardType {String}
    *  Either `default` or `daisy`
    * @return {Promise}

--- a/openBCIBoard.js
+++ b/openBCIBoard.js
@@ -23,6 +23,7 @@ function OpenBCIFactory () {
     simulate: false,
     simulatorBoardFailure: false,
     simulatorDaisyModuleAttached: false,
+    simulatorDaisyModuleCanBeAttached: true,
     simulatorFirmwareVersion: [k.OBCIFirmwareV1, k.OBCIFirmwareV2],
     simulatorFragmentation: [k.OBCISimulatorFragmentationNone, k.OBCISimulatorFragmentationRandom, k.OBCISimulatorFragmentationFullBuffers, k.OBCISimulatorFragmentationOneByOne],
     simulatorLatencyTime: 16,
@@ -41,80 +42,84 @@ function OpenBCIFactory () {
   };
 
   /**
-  * @description The initialization method to call first, before any other method.
-  * @param options (optional) - Board optional configurations.
-  *     - `baudRate` {Number} - Baud Rate, defaults to 115200. Manipulating this is allowed if
-  *                      firmware on board has been previously configured.
-  *
-  *     - `boardType` {String} - Specifies type of OpenBCI board.
-  *          3 Possible Boards:
-  *              `default` - 8 Channel OpenBCI board (Default)
-  *              `daisy` - 8 Channel OpenBCI board with Daisy Module. Total of 16 channels.
-  *              `ganglion` - 4 Channel board
-  *                  (NOTE: THIS IS IN-OP TIL RELEASE OF GANGLION BOARD 07/2016)
-  *
-  *     - `simulate` {Boolean} - Full functionality, just mock data. Must attach Daisy module by setting
-  *                  `simulatorDaisyModuleAttached` to `true` in order to get 16 channels. (Default `false`)
-  *
-  *     - `simulatorBoardFailure` {Boolean} - Simulates board communications failure. This occurs when the RFduino on
-  *                  the board is not polling the RFduino on the dongle. (Default `false`)
-  *
-  *     - `simulatorDaisyModuleAttached` {Boolean} - Simulates a daisy module being attached to the OpenBCI board.
-  *                  This is useful if you want to test how your application reacts to a user requesting 16 channels
-  *                  but there is no daisy module actually attached, or vice versa, where there is a daisy module
-  *                  attached and the user only wants to use 8 channels. (Default `false`)
-  *
-  *     - `simulatorFirmwareVersion` {String} - Allows simulator to be started with firmware version 2 features
-  *          2 Possible Options:
-  *              `v1` - Firmware Version 1 (Default)
-  *              `v2` - Firmware Version 2
-  *
-  *     - `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation, which
-  *                  occurs commonly in real devices.  It is recommended to test code with this enabled.
-  *          4 Possible Options:
-  *              `none` - do not fragment packets; output complete chunks immediately when produced (Default)
-  *              `random` - output random small chunks of data interspersed with full buffers
-  *              `fullBuffers` - allow buffers to fill up until the latency timer has expired
-  *              `oneByOne` - output each byte separately
-  *
-  *     - `simulatorLatencyTime` {Number} - The time in milliseconds to wait before sending partially full buffers,
-                     if `simulatorFragmentation` is specified. (Default `16`)
-  *
-  *     - `simulatorBufferSize` {Number} - The size of a full buffer of data, if `simulatorFragmentation` is
-  *                  specified. (Default `4096`)
-  *
-  *     - `simulatorHasAccelerometer` - {Boolean} - Sets simulator to send packets with accelerometer data. (Default `true`)
-  *
-  *     - `simulatorInjectAlpha` - {Boolean} - Inject a 10Hz alpha wave in Channels 1 and 2 (Default `true`)
-  *
-  *     - `simulatorInjectLineNoise` {String} - Injects line noise on channels.
-  *          3 Possible Options:
-  *              `60Hz` - 60Hz line noise (Default) [America]
-  *              `50Hz` - 50Hz line noise [Europe]
-  *              `none` - Do not inject line noise.
-  *
-  *     - `simulatorSampleRate` {Number} - The sample rate to use for the simulator. Simulator will set to 125 if
-  *                  `simulatorDaisyModuleAttached` is set `true`. However, setting this option overrides that
-  *                  setting and this sample rate will be used. (Default is `250`)
-  *
-  *     - `simulatorSerialPortFailure` {Boolean} - Simulates not being able to open a serial connection. Most likely
-  *                  due to a OpenBCI dongle not being plugged in.
-  *
-  *     - `sntpTimeSync` - {Boolean} Syncs the module up with an SNTP time server and uses that as single source
-  *                  of truth instead of local computer time. If you are running experiements on your local
-  *                  computer, keep this `false`. (Default `false`)
-  *
-  *     - `sntpTimeSyncHost` - {String} The ntp server to use, can be either sntp or ntp. (Defaults `pool.ntp.org`).
-  *
-  *     - `sntpTimeSyncPort` - {Number} The port to access the ntp server. (Defaults `123`)
-  *
-  *     - `verbose` {Boolean} - Print out useful debugging events. (Default `false`)
-  *
-  *     - `debug` {Boolean} - Print out a raw dump of bytes sent and received. (Default `false`)
-  *
-  * @constructor
-  * @author AJ Keller (@pushtheworldllc)
-  */
+   * @description The initialization method to call first, before any other method.
+   * @param options (optional) - Board optional configurations.
+   *     - `baudRate` {Number} - Baud Rate, defaults to 115200. Manipulating this is allowed if
+   *                      firmware on board has been previously configured.
+   *
+   *     - `boardType` {String} - Specifies type of OpenBCI board.
+   *          3 Possible Boards:
+   *              `default` - 8 Channel OpenBCI board (Default)
+   *              `daisy` - 8 Channel OpenBCI board with Daisy Module. Total of 16 channels.
+   *              `ganglion` - 4 Channel board
+   *                  (NOTE: THIS IS IN-OP TIL RELEASE OF GANGLION BOARD 07/2016)
+   *
+   *     - `simulate` {Boolean} - Full functionality, just mock data. Must attach Daisy module by setting
+   *                  `simulatorDaisyModuleAttached` to `true` in order to get 16 channels. (Default `false`)
+   *
+   *     - `simulatorBoardFailure` {Boolean} - Simulates board communications failure. This occurs when the RFduino on
+   *                  the board is not polling the RFduino on the dongle. (Default `false`)
+   *
+   *     - `simulatorDaisyModuleAttached` {Boolean} - Simulates a daisy module being attached to the OpenBCI board.
+   *                  This is useful if you want to test how your application reacts to a user requesting 16 channels
+   *                  but there is no daisy module actually attached, or vice versa, where there is a daisy module
+   *                  attached and the user only wants to use 8 channels. (Default `false`)
+   *
+   *     - `simulatorDaisyModuleCanBeAttached` {Boolean} - Allows the simulation of the a hot swapped daisy board.
+   *                  For example: You coule simulate if the board has only detected 8 channels and the user requested
+   *                  16 channels.  (Default `true`)
+   *
+   *     - `simulatorFirmwareVersion` {String} - Allows simulator to be started with firmware version 2 features
+   *          2 Possible Options:
+   *              `v1` - Firmware Version 1 (Default)
+   *              `v2` - Firmware Version 2
+   *
+   *     - `simulatorFragmentation` {String} - Specifies how to break packets to simulate fragmentation, which
+   *                  occurs commonly in real devices.  It is recommended to test code with this enabled.
+   *          4 Possible Options:
+   *              `none` - do not fragment packets; output complete chunks immediately when produced (Default)
+   *              `random` - output random small chunks of data interspersed with full buffers
+   *              `fullBuffers` - allow buffers to fill up until the latency timer has expired
+   *              `oneByOne` - output each byte separately
+   *
+   *     - `simulatorLatencyTime` {Number} - The time in milliseconds to wait before sending partially full buffers,
+   *                  if `simulatorFragmentation` is specified. (Default `16`)
+   *
+   *     - `simulatorBufferSize` {Number} - The size of a full buffer of data, if `simulatorFragmentation` is
+   *                  specified. (Default `4096`)
+   *
+   *     - `simulatorHasAccelerometer` - {Boolean} - Sets simulator to send packets with accelerometer data. (Default `true`)
+   *
+   *     - `simulatorInjectAlpha` - {Boolean} - Inject a 10Hz alpha wave in Channels 1 and 2 (Default `true`)
+   *
+   *     - `simulatorInjectLineNoise` {String} - Injects line noise on channels.
+   *          3 Possible Options:
+   *              `60Hz` - 60Hz line noise (Default) [America]
+   *              `50Hz` - 50Hz line noise [Europe]
+   *              `none` - Do not inject line noise.
+   *
+   *     - `simulatorSampleRate` {Number} - The sample rate to use for the simulator. Simulator will set to 125 if
+   *                  `simulatorDaisyModuleAttached` is set `true`. However, setting this option overrides that
+   *                  setting and this sample rate will be used. (Default is `250`)
+   *
+   *     - `simulatorSerialPortFailure` {Boolean} - Simulates not being able to open a serial connection. Most likely
+   *                  due to a OpenBCI dongle not being plugged in.
+   *
+   *     - `sntpTimeSync` - {Boolean} Syncs the module up with an SNTP time server and uses that as single source
+   *                  of truth instead of local computer time. If you are running experiements on your local
+   *                  computer, keep this `false`. (Default `false`)
+   *
+   *     - `sntpTimeSyncHost` - {String} The ntp server to use, can be either sntp or ntp. (Defaults `pool.ntp.org`).
+   *
+   *     - `sntpTimeSyncPort` - {Number} The port to access the ntp server. (Defaults `123`)
+   *
+   *     - `verbose` {Boolean} - Print out useful debugging events. (Default `false`)
+   *
+   *     - `debug` {Boolean} - Print out a raw dump of bytes sent and received. (Default `false`)
+   *
+   * @constructor
+   * @author AJ Keller (@pushtheworldllc)
+   */
   function OpenBCIBoard (options) {
     options = (typeof options !== 'function') && options || {};
     var opts = {};
@@ -206,6 +211,7 @@ function OpenBCIFactory () {
     this.timeOfPacketArrival = 0;
     this.writeOutDelay = k.OBCIWriteIntervalDelayMSShort;
     // Strings
+    this.portName = null;
 
     // NTP
     if (this.options.sntpTimeSync) {
@@ -254,6 +260,7 @@ function OpenBCIFactory () {
           alpha: this.options.simulatorInjectAlpha,
           boardFailure: this.options.simulatorBoardFailure,
           daisy: this.options.simulatorDaisyModuleAttached,
+          daisyCanBeAttached: this.options.simulatorDaisyModuleCanBeAttached,
           drift: this.options.simulatorInternalClockDrift,
           firmwareVersion: this.options.simulatorFirmwareVersion,
           fragmentation: this.options.simulatorFragmentation,
@@ -378,13 +385,23 @@ function OpenBCIFactory () {
     return this.serial.isOpen();
   };
 
+
   /**
   * @description Checks if the board is currently sending samples.
   * @returns {boolean} - True if streaming.
   */
+  OpenBCIBoard.prototype.isSimulating = function () {
+    return this.options.simulate;
+  };
+
+  /**
+   * @description Checks if the board is currently sending samples.
+   * @returns {boolean} - True if streaming.
+   */
   OpenBCIBoard.prototype.isStreaming = function () {
     return this._streaming;
   };
+
 
   /**
   * @description Sends a start streaming command to the board.
@@ -1013,6 +1030,14 @@ function OpenBCIFactory () {
   };
 
   /**
+   * Get the board type.
+   * @return boardType: string
+   */
+  OpenBCIBoard.prototype.getBoardType = function() {
+    return this.info.boardType;
+  };
+
+  /**
    * Get the core info object.
    * @return {{boardType: string, sampleRate: number, firmware: string, numberOfChannels: number, missedPackets: number}}
    */
@@ -1025,7 +1050,7 @@ function OpenBCIFactory () {
    * @param boardType {String}
    *  `default` or `daisy`. Defaults to `default`.
    */
-  OpenBCIBoard.prototype.setInfoForBoardType = function(boardType) {
+  OpenBCIBoard.prototype.overrideInfoForBoardType = function(boardType) {
     switch (boardType) {
       case k.OBCIBoardDaisy:
         this.info.boardType = k.OBCIBoardDaisy;
@@ -1043,20 +1068,60 @@ function OpenBCIFactory () {
 
   /**
    * Used to set the max number of channels on the Cyton board.
-   * @param numberOfChannels {number}
-   *  Either 8 or 16
+   * @param boardType {String}
+   *  Either `default` or `daisy`
    * @return {Promise}
    */
-  OpenBCIBoard.prototype.setMaxChannels = function (numberOfChannels) {
-    if (numberOfChannels === k.OBCINumberOfChannelsDefault) {
-      this.curParsingMode = k.OBCIParsingEOT;
-      return this.write(k.OBCIChannelMaxNumber8);
-    } else if (numberOfChannels === k.OBCINumberOfChannelsDaisy) {
-      this.curParsingMode = k.OBCIParsingEOT;
-      return this.write(k.OBCIChannelMaxNumber16);
-    } else {
-      return Promise.reject('invalid number of channels');
-    }
+  OpenBCIBoard.prototype.hardSetBoardType = function (boardType) {
+    if (this.isStreaming()) return Promise.reject('Must not be streaming!');
+    return new Promise((resolve, reject) => {
+      const eotFunc = (data) => {
+        switch (data.slice(0, data.length - k.OBCIParseEOT.length).toString()) {
+          case k.OBCIChannelMaxNumber8NoDaisyToRemove:
+            this.overrideInfoForBoardType(k.OBCIBoardDefault);
+            resolve('no daisy to remove');
+            break;
+          case k.OBCIChannelMaxNumber8SuccessDaisyRemoved:
+            this.overrideInfoForBoardType(k.OBCIBoardDefault);
+            resolve('daisy removed');
+            break;
+          case k.OBCIChannelMaxNumber16DaisyAlreadyAttached:
+            this.overrideInfoForBoardType(k.OBCIBoardDaisy);
+            resolve('daisy already attached');
+            break;
+          case k.OBCIChannelMaxNumber16DaisyAttached:
+            this.overrideInfoForBoardType(k.OBCIBoardDaisy);
+            resolve('daisy attached');
+            break;
+          case k.OBCIChannelMaxNumber16NoDaisyAttached:
+            this.overrideInfoForBoardType(k.OBCIBoardDefault);
+            reject('unable to attach daisy');
+            break;
+          default:
+            reject(Error('invalid return, board may not be configured correctly.'));
+            break;
+        }
+      };
+      if (boardType === k.OBCIBoardDefault) {
+        this.curParsingMode = k.OBCIParsingEOT;
+        this.once(k.OBCIEmitterEot, eotFunc);
+        this.write(k.OBCIChannelMaxNumber8)
+          .catch((err) => {
+            this.removeListener(k.OBCIEmitterEot, eotFunc);
+            reject(err);
+          });
+      } else if (boardType === k.OBCIBoardDaisy) {
+        this.curParsingMode = k.OBCIParsingEOT;
+        this.once(k.OBCIEmitterEot, eotFunc);
+        this.write(k.OBCIChannelMaxNumber16)
+          .catch((err) => {
+            this.removeListener(k.OBCIEmitterEot, eotFunc);
+            reject(err);
+          });
+      } else {
+        reject('invalid board type');
+      }
+    });
   };
 
   /**
@@ -1854,9 +1919,9 @@ function OpenBCIFactory () {
    */
   OpenBCIBoard.prototype._processParseBufferForReset = function (dataBuffer) {
     if (openBCISample.countADSPresent(dataBuffer) === 2) {
-      this.setInfoForBoardType(k.OBCIBoardDaisy);
+      this.overrideInfoForBoardType(k.OBCIBoardDaisy);
     } else {
-      this.setInfoForBoardType(k.OBCIBoardDefault);
+      this.overrideInfoForBoardType(k.OBCIBoardDefault);
     }
 
     if (openBCISample.findV2Firmware(dataBuffer)) {

--- a/openBCIConstants.js
+++ b/openBCIConstants.js
@@ -342,6 +342,7 @@ const obciEmitterClose = 'close';
 const obciEmitterDroppedPacket = 'droppedPacket';
 const obciEmitterEot = 'eot';
 const obciEmitterError = 'error';
+const obciEmitterHardSet = 'hardSet';
 const obciEmitterImpedanceArray = 'impedanceArray';
 const obciEmitterQuery = 'query';
 const obciEmitterRawDataPacket = 'rawDataPacket';
@@ -907,6 +908,7 @@ module.exports = {
   OBCIEmitterDroppedPacket: obciEmitterDroppedPacket,
   OBCIEmitterEot: obciEmitterEot,
   OBCIEmitterError: obciEmitterError,
+  OBCIEmitterHardSet: obciEmitterHardSet,
   OBCIEmitterImpedanceArray: obciEmitterImpedanceArray,
   OBCIEmitterQuery: obciEmitterQuery,
   OBCIEmitterRawDataPacket: obciEmitterRawDataPacket,

--- a/openBCIConstants.js
+++ b/openBCIConstants.js
@@ -156,6 +156,11 @@ const obciMiscSoftReset = 'v';
 /** 16 Channel Commands */
 const obciChannelMaxNumber8 = 'c';
 const obciChannelMaxNumber16 = 'C';
+const obciChannelMaxNumber8NoDaisyToRemove = '';
+const obciChannelMaxNumber8SuccessDaisyRemoved = 'daisy removed';
+const obciChannelMaxNumber16DaisyAlreadyAttached = '16';
+const obciChannelMaxNumber16DaisyAttached = 'daisy attached16';
+const obciChannelMaxNumber16NoDaisyAttached = 'no daisy to attach!8';
 
 /** 60Hz line filter */
 const obciFilterDisable = 'g';
@@ -335,6 +340,7 @@ const obciRadioBaudRateFastStr = 'fast';
 /** Emitters */
 const obciEmitterClose = 'close';
 const obciEmitterDroppedPacket = 'droppedPacket';
+const obciEmitterEot = 'eot';
 const obciEmitterError = 'error';
 const obciEmitterImpedanceArray = 'impedanceArray';
 const obciEmitterQuery = 'query';
@@ -724,6 +730,11 @@ module.exports = {
   /** 16 Channel Commands */
   OBCIChannelMaxNumber8: obciChannelMaxNumber8,
   OBCIChannelMaxNumber16: obciChannelMaxNumber16,
+  OBCIChannelMaxNumber8NoDaisyToRemove: obciChannelMaxNumber8NoDaisyToRemove,
+  OBCIChannelMaxNumber8SuccessDaisyRemoved: obciChannelMaxNumber8SuccessDaisyRemoved,
+  OBCIChannelMaxNumber16DaisyAlreadyAttached: obciChannelMaxNumber16DaisyAlreadyAttached,
+  OBCIChannelMaxNumber16DaisyAttached: obciChannelMaxNumber16DaisyAttached,
+  OBCIChannelMaxNumber16NoDaisyAttached: obciChannelMaxNumber16NoDaisyAttached,
   /** Filters */
   OBCIFilterDisable: obciFilterDisable,
   OBCIFilterEnable: obciFilterEnable,
@@ -894,6 +905,7 @@ module.exports = {
   /** Emitters */
   OBCIEmitterClose: obciEmitterClose,
   OBCIEmitterDroppedPacket: obciEmitterDroppedPacket,
+  OBCIEmitterEot: obciEmitterEot,
   OBCIEmitterError: obciEmitterError,
   OBCIEmitterImpedanceArray: obciEmitterImpedanceArray,
   OBCIEmitterQuery: obciEmitterQuery,

--- a/openBCISample.js
+++ b/openBCISample.js
@@ -1119,7 +1119,7 @@ function isSuccessInBuffer (dataBuffer) {
  */
 function stripToEOTBuffer (dataBuffer) {
   let indexOfEOT = dataBuffer.indexOf(k.OBCIParseEOT);
-  if (indexOfEOT > 0) {
+  if (indexOfEOT >= 0) {
     indexOfEOT += k.OBCIParseEOT.length;
   } else {
     return dataBuffer;

--- a/openBCISimulator.js
+++ b/openBCISimulator.js
@@ -15,6 +15,7 @@ function OpenBCISimulatorFactory () {
     alpha: true,
     boardFailure: false,
     daisy: false,
+    daisyCanBeAttached: true,
     drift: 0,
     firmwareVersion: [k.OBCIFirmwareV1, k.OBCIFirmwareV2],
     fragmentation: [k.OBCISimulatorFragmentationNone, k.OBCISimulatorFragmentationRandom, k.OBCISimulatorFragmentationFullBuffers, k.OBCISimulatorFragmentationOneByOne],
@@ -250,6 +251,30 @@ function OpenBCISimulatorFactory () {
             this._output(new Buffer(k.OBCISyncTimeSent));
             this._syncUp();
           }, 10);
+        }
+        break;
+      case k.OBCIChannelMaxNumber8:
+        if (this.options.daisy) {
+          this.options.daisy = false;
+          this._output(new Buffer(k.OBCIChannelMaxNumber8SuccessDaisyRemoved));
+          this._printEOT();
+        } else {
+          this._printEOT();
+        }
+        break;
+      case k.OBCIChannelMaxNumber16:
+        if (this.options.daisy) {
+          this._output(new Buffer(k.OBCIChannelMaxNumber16DaisyAlreadyAttached));
+          this._printEOT();
+        } else {
+          if (this.options.daisyCanBeAttached) {
+            this.options.daisy = true;
+            this._output(new Buffer(k.OBCIChannelMaxNumber16DaisyAttached));
+            this._printEOT();
+          } else {
+            this._output(new Buffer(k.OBCIChannelMaxNumber16NoDaisyAttached));
+            this._printEOT();
+          }
         }
         break;
       default:

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci",
-  "version": "1.4.4",
+  "version": "1.4.5",
   "description": "The official Node.js SDK for the OpenBCI Biosensor Board.",
   "main": "openBCIBoard",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci",
-  "version": "1.4.5",
+  "version": "1.5.0",
   "description": "The official Node.js SDK for the OpenBCI Biosensor Board.",
   "main": "openBCIBoard",
   "scripts": {

--- a/test/OpenBCIConstants-test.js
+++ b/test/OpenBCIConstants-test.js
@@ -443,6 +443,13 @@ describe('OpenBCIConstants', function () {
     it('sets max of 16', function () {
       assert.equal('C', k.OBCIChannelMaxNumber16);
     });
+    it('has correct return messages', function () {
+      assert.equal('', k.OBCIChannelMaxNumber8NoDaisyToRemove);
+      assert.equal('daisy removed', k.OBCIChannelMaxNumber8SuccessDaisyRemoved);
+      assert.equal('16', k.OBCIChannelMaxNumber16DaisyAlreadyAttached);
+      assert.equal('daisy attached16', k.OBCIChannelMaxNumber16DaisyAttached);
+      assert.equal('no daisy to attach!', k.OBCIChannelMaxNumber16NoDaisyAttached);
+    });
   });
   describe('On board filters', function () {
     it('disable', function () {
@@ -1439,6 +1446,9 @@ describe('OpenBCIConstants', function () {
     });
     it('Event Emitter Dropped Packet', function () {
       assert.equal('droppedPacket', k.OBCIEmitterDroppedPacket);
+    });
+    it('Event Emitter EOT', function () {
+      assert.equal('eot', k.OBCIEmitterEot);
     });
     it('Event Emitter Error', function () {
       assert.equal('error', k.OBCIEmitterError);

--- a/test/OpenBCIConstants-test.js
+++ b/test/OpenBCIConstants-test.js
@@ -448,7 +448,7 @@ describe('OpenBCIConstants', function () {
       assert.equal('daisy removed', k.OBCIChannelMaxNumber8SuccessDaisyRemoved);
       assert.equal('16', k.OBCIChannelMaxNumber16DaisyAlreadyAttached);
       assert.equal('daisy attached16', k.OBCIChannelMaxNumber16DaisyAttached);
-      assert.equal('no daisy to attach!', k.OBCIChannelMaxNumber16NoDaisyAttached);
+      assert.equal('no daisy to attach!8', k.OBCIChannelMaxNumber16NoDaisyAttached);
     });
   });
   describe('On board filters', function () {
@@ -1452,6 +1452,9 @@ describe('OpenBCIConstants', function () {
     });
     it('Event Emitter Error', function () {
       assert.equal('error', k.OBCIEmitterError);
+    });
+    it('Event Emitter Hard Set', function () {
+      assert.equal('hardSet', k.OBCIEmitterHardSet);
     });
     it('Event Emitter Impedance Array', function () {
       assert.equal('impedanceArray', k.OBCIEmitterImpedanceArray);

--- a/test/OpenBCISample-test.js
+++ b/test/OpenBCISample-test.js
@@ -1221,6 +1221,21 @@ $$$`);
       }
       expect(openBCISample.stripToEOTBuffer(buf).toString()).to.equal(buf.toString());
     });
+    it('should slice the buffer after just eot $$$', function () {
+      let eotBuf = null;
+      let bufPost = null;
+      if (k.getVersionNumber(process.version) >= 6) {
+        // From introduced in node version 6.x.x
+        eotBuf = Buffer.from(k.OBCIParseEOT);
+        bufPost = Buffer.from('tacos');
+      } else {
+        eotBuf = new Buffer(k.OBCIParseEOT);
+        bufPost = new Buffer('tacos');
+      }
+
+      let totalBuf = Buffer.concat([eotBuf, bufPost]);
+      expect(openBCISample.stripToEOTBuffer(totalBuf).toString()).to.equal(bufPost.toString());
+    });
     it('should slice the buffer after eot $$$', function () {
       let bufPre = null;
       let eotBuf = null;

--- a/test/openBCIBoard-radio-test.js
+++ b/test/openBCIBoard-radio-test.js
@@ -1,0 +1,954 @@
+'use strict';
+var bluebirdChecks = require('./bluebirdChecks');
+var sinon = require('sinon');
+var chai = require('chai');
+var expect = chai.expect;
+var should = chai.should(); // eslint-disable-line no-unused-vars
+var openBCIBoard = require('../openBCIBoard');
+var openBCISample = openBCIBoard.OpenBCISample;
+var k = openBCISample.k;
+var chaiAsPromised = require('chai-as-promised');
+var sinonChai = require('sinon-chai');
+var sinonAsPromised = require('sinon-as-promised')(bluebirdChecks.BluebirdPromise);
+var fs = require('fs');
+
+chai.use(chaiAsPromised);
+chai.use(sinonChai);
+
+describe('openbci-radios', function () {
+  this.timeout(2000);
+  var ourBoard, masterPortName, realBoard;
+
+  before(function (done) {
+    ourBoard = new openBCIBoard.OpenBCIBoard();
+    ourBoard.autoFindOpenBCIBoard()
+      .then(portName => {
+        ourBoard = null;
+        realBoard = true;
+        masterPortName = portName;
+        done();
+      })
+      .catch(() => {
+        ourBoard = null;
+        realBoard = false;
+        masterPortName = k.OBCISimulatorPortName;
+        done();
+      });
+  });
+  after(done => {
+    if (ourBoard) {
+      if (ourBoard['connected']) {
+        ourBoard.disconnect()
+          .then(() => {
+            done();
+          })
+          .catch(err => {
+            done(err);
+          });
+      } else {
+        done();
+      }
+    } else {
+      done();
+    }
+  });
+
+  describe('#radioChannelSet', function () {
+    afterEach(function (done) {
+      if (ourBoard.isConnected()) {
+        ourBoard.disconnect().then(() => {
+          done();
+        }).catch(() => done);
+      } else {
+        done();
+      }
+    });
+    afterEach(() => bluebirdChecks.noPendingPromises());
+
+    it('should not change the channel number if not connected', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.radioChannelGet().should.be.rejected.and.notify(done);
+    });
+
+    it('should reject if streaming', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.streamStart()
+              .then(() => {
+                ourBoard.radioChannelSet(1).then(() => {
+                  done('should have rejected');
+                }).catch(() => {
+                  done(); // Test pass
+                });
+              }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+    it('should reject if not firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSet(1).should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+    it('should reject if a number is not sent as input', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSet('1').should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should reject if no channel number is presented as arg', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSet().should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should reject if the requested new channel number is lower than 0', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSet(-1).should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should reject if the requested new channel number is higher than 25', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSet(26).should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should not change the channel if the board is not communicating with the host', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorBoardFailure: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSet(1).should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should change the channel if connected, not steaming, and using firmware version 2+', function (done) {
+      var newChannelNumber = 2;
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSet(newChannelNumber).then(channelNumber => {
+              expect(channelNumber).to.be.equal(newChannelNumber);
+              done();
+            }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+  });
+
+  describe('#radioChannelSetHostOverride', function () {
+    afterEach(function (done) {
+      if (ourBoard.isConnected()) {
+        ourBoard.disconnect().then(() => {
+          done();
+        }).catch(() => done);
+      } else {
+        done();
+      }
+    });
+    afterEach(() => bluebirdChecks.noPendingPromises());
+    it('should not change the channel number if not connected', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.radioChannelSetHostOverride().should.be.rejected.and.notify(done);
+    });
+    it('should reject if streaming', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.streamStart()
+              .then(() => {
+                ourBoard.radioChannelSetHostOverride(1).then(() => {
+                  done('should have rejected');
+                }).catch(() => {
+                  done(); // Test pass
+                });
+              }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+    it('should reject if a number is not sent as input', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSetHostOverride('1').should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+    it('should reject if no channel number is presented as arg', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSetHostOverride().should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+    it('should reject if the requested new channel number is lower than 0', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSetHostOverride(-1).should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+    it('should reject if the requested new channel number is higher than 25', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSetHostOverride(26).should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+    it('should change the channel if connected, not steaming, and using firmware version 2+', function (done) {
+      var newChannelNumber = 2;
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelSetHostOverride(newChannelNumber).then(channelNumber => {
+              expect(channelNumber).to.be.equal(newChannelNumber);
+              done();
+            }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+  });
+
+  describe('#radioChannelGet', function () {
+    afterEach(function (done) {
+      if (ourBoard.isConnected()) {
+        ourBoard.disconnect().then(() => {
+          done();
+        }).catch(() => done);
+      } else {
+        done();
+      }
+    });
+    afterEach(() => bluebirdChecks.noPendingPromises());
+
+    it('should not query if not connected', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.radioChannelGet().should.be.rejected.and.notify(done);
+    });
+    it('should not query if streaming', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.streamStart()
+              .then(() => {
+                ourBoard.radioChannelGet().then(() => {
+                  done('should have rejected');
+                }).catch(() => {
+                  done(); // Test pass
+                });
+              }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+    it('should not query if not firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelGet().should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+    it('should query if firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelGet().then(res => {
+              expect(res.channelNumber).to.be.within(k.OBCIRadioChannelMin, k.OBCIRadioChannelMax);
+              done();
+            }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+    it('should get message even if the board is not communicating with dongle', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorBoardFailure: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioChannelGet().should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+  });
+
+  describe('#radioPollTimeSet', function () {
+    afterEach(function (done) {
+      if (ourBoard.isConnected()) {
+        ourBoard.disconnect().then(() => {
+          done();
+        }).catch(() => done);
+      } else {
+        done();
+      }
+    });
+    afterEach(() => bluebirdChecks.noPendingPromises());
+    it('should not change the channel number if not connected', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.radioPollTimeSet().should.be.rejected.and.notify(done);
+    });
+
+    it('should reject if streaming', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.streamStart()
+              .then(() => {
+                ourBoard.radioPollTimeSet(1).then(() => {
+                  done('should have rejected');
+                }).catch(() => {
+                  done(); // Test pass
+                });
+              }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should reject if not firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioPollTimeSet(1).should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should reject if a number is not sent as input', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioPollTimeSet('1').should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should reject if no poll time is presented as arg', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioPollTimeSet().should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should reject if the requested new poll time is lower than 0', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioPollTimeSet(-1).should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should reject if the requested new poll time is higher than 255', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioPollTimeSet(256).should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should not change the poll time if the board is not communicating with the host', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorBoardFailure: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioPollTimeSet(1).should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+
+    it('should change the poll time if connected, not steaming, and using firmware version 2+', function (done) {
+      var newPollTime = 69;
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioPollTimeSet(newPollTime).then(() => {
+              done();
+            }).catch(err => {
+              done(err);
+            });
+          });
+        }).catch(err => done(err));
+    });
+  });
+
+  describe('#radioPollTimeGet', function () {
+    afterEach(function (done) {
+      if (ourBoard.isConnected()) {
+        ourBoard.disconnect().then(() => {
+          done();
+        }).catch(() => done);
+      } else {
+        done();
+      }
+    });
+    afterEach(() => bluebirdChecks.noPendingPromises());
+
+    it('should not query if not connected', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.radioPollTimeGet().should.be.rejected.and.notify(done);
+    });
+    it('should not query if streaming', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.streamStart()
+              .then(() => {
+                ourBoard.radioPollTimeGet().then(() => {
+                  done('should have rejected');
+                }).catch(() => {
+                  done(); // Test pass
+                });
+              }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+    it('should not query if not firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioPollTimeGet().should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+    it('should query if firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioPollTimeGet().then(pollTime => {
+              expect(pollTime).to.be.greaterThan(0);
+              done();
+            }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+    it('should get failure message if the board is not communicating with dongle', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorBoardFailure: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioPollTimeGet().should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+  });
+
+  describe('#radioBaudRateSet', function () {
+    afterEach(function (done) {
+      if (ourBoard.isConnected()) {
+        ourBoard.disconnect().then(() => {
+          done();
+        }).catch(() => done);
+      } else {
+        done();
+      }
+    });
+    afterEach(() => bluebirdChecks.noPendingPromises());
+
+    it('should not try to set baud rate if not connected', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.radioBaudRateSet('default').should.be.rejected.and.notify(done);
+    });
+    it('should reject if no input', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.radioBaudRateSet().should.be.rejected.and.notify(done);
+    });
+    it('should be rejected if input type incorrect', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.radioBaudRateSet(1).should.be.rejected.and.notify(done);
+    });
+    it('should not try to change the baud rate if streaming', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.streamStart()
+              .then(() => {
+                ourBoard.radioBaudRateSet('default').then(() => {
+                  done('should have rejected');
+                }).catch(() => {
+                  done(); // Test pass
+                });
+              }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+    it('should not try to change the baud rate if not firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioBaudRateSet('default').should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+    it('should set the baud rate to default if firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioBaudRateSet('default').then(baudrate => {
+              expect(baudrate).to.be.equal(115200);
+              done();
+            }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+    it('should set the baud rate to fast if firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioBaudRateSet('fast').then(baudrate => {
+              expect(baudrate).to.be.equal(230400);
+              done();
+            }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+  });
+
+  describe('#radioSystemStatusGet', function () {
+    afterEach(function (done) {
+      if (ourBoard.isConnected()) {
+        ourBoard.disconnect().then(() => {
+          done();
+        }).catch(() => done);
+      } else {
+        done();
+      }
+    });
+    afterEach(() => bluebirdChecks.noPendingPromises());
+
+    it('should not get system status if not connected', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.radioSystemStatusGet().should.be.rejected.and.notify(done);
+    });
+    it('should not get system status if streaming', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.streamStart()
+              .then(() => {
+                ourBoard.radioSystemStatusGet().then(() => {
+                  done('should have rejected');
+                }).catch(() => {
+                  done(); // Test pass
+                });
+              }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+    it('should not get system status if not firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioSystemStatusGet().should.be.rejected.and.notify(done);
+          });
+        }).catch(err => done(err));
+    });
+    it('should get up system status if firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2'
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioSystemStatusGet().then(isUp => {
+              expect(isUp).to.be.true;
+              done();
+            }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+    it('should get down system status if firmware version 2', function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulate: true,
+        simulatorFirmwareVersion: 'v2',
+        simulatorBoardFailure: true
+      });
+      ourBoard.connect(k.OBCISimulatorPortName)
+        .then(() => {
+          ourBoard.once('ready', () => {
+            ourBoard.radioSystemStatusGet().then(isUp => {
+              expect(isUp).to.be.false;
+              done();
+            }).catch(err => done(err));
+          });
+        }).catch(err => done(err));
+    });
+  });
+
+  describe('#radioTests', function () {
+    this.timeout(0);
+    before(function (done) {
+      ourBoard = new openBCIBoard.OpenBCIBoard({
+        verbose: true,
+        simulatorFirmwareVersion: 'v2',
+        simulatorFragmentation: k.OBCISimulatorFragmentationRandom
+      });
+      ourBoard.connect(masterPortName).catch(err => done(err));
+
+      ourBoard.once('ready', () => {
+        done();
+      });
+    });
+    after(function (done) {
+      if (ourBoard.isConnected()) {
+        ourBoard.disconnect().then(() => {
+          done();
+        });
+      } else {
+        done();
+      }
+    });
+    after(() => bluebirdChecks.noPendingPromises());
+    it('should be able to get the channel number', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      // The channel number should be between 0 and 25. Those are hard limits.
+      ourBoard.radioChannelGet().then(res => {
+        expect(res.channelNumber).to.be.within(0, 25);
+        done();
+      }).catch(err => done(err));
+    });
+    it('should be able to set the channel to 1', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      ourBoard.radioChannelSet(1).then(channelNumber => {
+        expect(channelNumber).to.equal(1);
+        done();
+      }).catch(err => done(err));
+    });
+    it('should be able to set the channel to 2', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      ourBoard.radioChannelSet(2).then(channelNumber => {
+        expect(channelNumber).to.equal(2);
+        done();
+      }).catch(err => done(err));
+    });
+    it('should be able to set the channel to 25', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      ourBoard.radioChannelSet(25).then(channelNumber => {
+        expect(channelNumber).to.equal(25);
+        done();
+      }).catch(err => done(err));
+    });
+    it('should be able to set the channel to 5', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      ourBoard.radioChannelSet(5).then(channelNumber => {
+        expect(channelNumber).to.equal(5);
+        done();
+      }).catch(err => done(err));
+    });
+    it('should be able to override host channel number, verify system is down, set the host back and verify system is up', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      var systemChanNumber = 0;
+      var newChanNum = 0;
+      // var timey = Date.now()
+      // Get the current system channel
+      ourBoard.radioChannelGet()
+        .then(res => {
+          // Store it
+          systemChanNumber = res.channelNumber;
+          // console.log(`system channel number: ${res.channelNumber}`)
+          if (systemChanNumber === 25) {
+            newChanNum = 24;
+          } else {
+            newChanNum = systemChanNumber + 1;
+          }
+          // Call to change just the host
+          return ourBoard.radioChannelSetHostOverride(newChanNum);
+        })
+        .then(newChanNumActual => {
+          expect(newChanNumActual).to.equal(newChanNum);
+          // timey = Date.now()
+          // console.log(`new chan ${newChanNumActual} got`, timey, '0ms')
+          return new Promise((resolve, reject) => {
+            setTimeout(function () {
+              // console.log(`get status`, Date.now(), `${Date.now() - timey}ms`)
+              ourBoard.radioSystemStatusGet().then(isUp => {
+                // console.log('resolving', Date.now(), `${Date.now() - timey}ms`)
+                resolve(isUp);
+              })
+                .catch(err => {
+                  reject(err);
+                });
+            }, 270); // Should be accurate after 270 seconds
+          });
+        })
+        .then(isUp => {
+          // console.log(`isUp test`, Date.now(), `${Date.now() - timey}ms`)
+          expect(isUp).to.be.false;
+          return ourBoard.radioChannelSetHostOverride(systemChanNumber); // Set back to good
+        })
+        .then(newChanNumActual => {
+          // Verify we set it back to normal
+          expect(newChanNumActual).to.equal(systemChanNumber);
+          return ourBoard.radioSystemStatusGet();
+        })
+        .then(isUp => {
+          expect(isUp).to.be.true;
+          done();
+        })
+        .catch(err => done(err));
+    });
+    it('should be able to get the poll time', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      ourBoard.radioPollTimeGet().should.eventually.be.greaterThan(0).and.notify(done);
+    });
+    it('should be able to set the poll time', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      ourBoard.radioPollTimeSet(80).should.become(80).and.notify(done);
+    });
+    it('should be able to change to default baud rate', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      ourBoard.radioBaudRateSet('default').should.become(115200).and.notify(done);
+    });
+    it('should be able to change to fast baud rate', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      ourBoard.radioBaudRateSet('fast').then(newBaudRate => {
+        expect(newBaudRate).to.equal(230400);
+        return ourBoard.radioBaudRateSet('default');
+      }).then(() => {
+        done();
+      }).catch(err => done(err));
+    });
+    it('should be able to set the system status', function (done) {
+      // Don't test if not using v2
+      if (!ourBoard.usingVersionTwoFirmware()) return done();
+      ourBoard.radioSystemStatusGet().then(isUp => {
+        expect(isUp).to.be.true;
+        done();
+      }).catch(err => done(err));
+    });
+  });
+
+});

--- a/test/openBCIBoard-test.js
+++ b/test/openBCIBoard-test.js
@@ -756,6 +756,104 @@ describe('openbci-sdk', function () {
           done();
         }
       });
+      it('daisy attached in soft reset, daisy requested by user in options, module is successful', function (done) {
+        if (ourBoard.isSimulating()) {
+          // Turn hardSet on
+          ourBoard.options.hardSet = true;
+          // Set the options to daisy boardType
+          ourBoard.options.boardType = k.OBCIBoardDaisy;
+          // The simulator does have a daisy
+          ourBoard.options.simulatorDaisyModuleAttached = true;
+          // The simulator is able to attach daisy
+          ourBoard.options.simulatorDaisyModuleCanBeAttached = true;
+          const failTestWithErr = (err) => {
+            ourBoard.options.hardSet = false;
+            ourBoard.disconnect().then(() => { // call disconnect
+              done(err);
+            }).catch(() => {
+              done(err);
+            });
+          };
+          var hardSetFuncFailure = () => {
+            ourBoard.removeListener('ready', readyFuncSuccess);
+            ourBoard.removeListener('hardSet', hardSetFuncFailure);
+            failTestWithErr('should not hardSet');
+          };
+          var errorFuncTestFailure = () => {
+            ourBoard.removeListener('ready', readyFuncSuccess);
+            ourBoard.removeListener('hardSet', hardSetFuncFailure);
+            failTestWithErr('should not error');
+          };
+          var readyFuncSuccess = () => {
+            ourBoard.removeListener('error', errorFuncTestFailure);
+            ourBoard.removeListener('hardSet', hardSetFuncFailure);
+            // Verify the module is still default
+            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDaisy);
+            ourBoard.options.hardSet = false;
+            ourBoard.disconnect().then(() => { // call disconnect
+              done();
+            }).catch(() => {
+              done();
+            });
+          };
+
+          ourBoard.once('error', errorFuncTestFailure);
+          ourBoard.once('ready', readyFuncSuccess);
+          ourBoard.once('hardSet', hardSetFuncFailure);
+          ourBoard.connect(masterPortName).catch(err => done(err));
+        } else {
+          done();
+        }
+      });
+      it('no daisy attached in soft reset, default requested by user in options, module is successful', function (done) {
+        if (ourBoard.isSimulating()) {
+          // Turn hardSet on
+          ourBoard.options.hardSet = true;
+          // Set the options to default boardType
+          ourBoard.options.boardType = k.OBCIBoardDefault;
+          // The simulator does not have a daisy
+          ourBoard.options.simulatorDaisyModuleAttached = false;
+          // The simulator is able to attach daisy
+          ourBoard.options.simulatorDaisyModuleCanBeAttached = false;
+          const failTestWithErr = (err) => {
+            ourBoard.options.hardSet = false;
+            ourBoard.disconnect().then(() => { // call disconnect
+              done(err);
+            }).catch(() => {
+              done(err);
+            });
+          };
+          var hardSetFuncFailure = () => {
+            ourBoard.removeListener('ready', readyFuncSuccess);
+            ourBoard.removeListener('hardSet', hardSetFuncFailure);
+            failTestWithErr('should not hard set');
+          };
+          var errorFuncTestFailure = () => {
+            ourBoard.removeListener('ready', readyFuncSuccess);
+            ourBoard.removeListener('hardSet', hardSetFuncFailure);
+            failTestWithErr('should not emit error');
+          };
+          var readyFuncSuccess = () => {
+            ourBoard.removeListener('error', errorFuncTestFailure);
+            ourBoard.removeListener('hardSet', hardSetFuncFailure);
+            // Verify the module is still default
+            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDefault);
+            ourBoard.options.hardSet = false;
+            ourBoard.disconnect().then(() => { // call disconnect
+              done();
+            }).catch(() => {
+              done();
+            });
+          };
+
+          ourBoard.once('error', errorFuncTestFailure);
+          ourBoard.once('ready', readyFuncSuccess);
+          ourBoard.once('hardSet', hardSetFuncFailure);
+          ourBoard.connect(masterPortName).catch(err => done(err));
+        } else {
+          done();
+        }
+      });
     });
     describe('#connected', function () {
       beforeEach(function (done) {


### PR DESCRIPTION
# 1.5.0

### New Features
* New simulator option `simulatorDaisyModuleCanBeAttached` - Boolean, deafults to true, allows the simulation of the a hot swapped daisy board or simulates a misinformed module.
* New `EventEmitter` - `hardSet` - for when the module detects the board is not configured as the options for the module intended and tries to save itself. i.e. when the `daisy` option is `true` and a soft reset message is parsed and the module determines that a daisy was not detected, the module will emit `hardSet` then send an attach daisy command to recover. Either `error` will be emitted if unable to attach or `ready` will be emitted if success.
* Add example for streaming with `daisy` and `hardSet`.

### Breaking changes
* `.setInfoForBoardType()` changed to `.overrideInfoForBoardType()` to elevate it's dangerous nature.
* `.setMaxChannels()` changed to `.hardSetBoardType()` and input changed from numerical to string: 8 and 16 to `default` and `daisy` respectively.

### Bug Fixes
* Fixes #131 - 16 chan not working by sending a channel command and parsing the return.
* Fixed bug where end of transmission characters would not be ejected from buffer.
 
### Enhancements
* Separated radio tests from main board test file.