### PR TITLE
Lab Streaming Layer example

### DIFF
--- a/README.md
+++ b/README.md
@@ -849,15 +849,15 @@ Stop logging to the SD card and close any open file. If you are not streaming wh
 
 ### <a name="method-set-info-for-board-type"></a> .setInfoForBoardType(boardType)
 
-Set the info property for board type. 
+Set the info property for board type.
 
-**Note: This has the potential to change the way data is parsed** 
- 
+**Note: This has the potential to change the way data is parsed**
+
 **_boardType_**
 
 A String indicating the number of channels.
 
-* `default` - Default board: Sample rate is `250Hz` and number of channels is `8`. 
+* `default` - Default board: Sample rate is `250Hz` and number of channels is `8`.
 * `daisy` - Daisy board: Sample rate is `125Hz` and number of channels is `16`.
 
 **_Returns_** a promise, fulfilled if the command was sent to the write queue. Rejects if input is not `8` or `16`.
@@ -865,7 +865,7 @@ A String indicating the number of channels.
 ### <a name="method-set-max-channels"></a> .setMaxChannels(numberOfChannels)
 
 Sends a command to the board to set the max channels. If you have a daisy attached, calling this function will re-sniff for the daisy ADS and attempt to use it.
- 
+
 **_numberOfChannels_**
 
 A Number indicating the number of channels.
@@ -1158,44 +1158,23 @@ The name of the simulator port.
 
 [LabStreamingLayer](https://github.com/sccn/labstreaminglayer) by SCCN is a stream management tool designed to time-synchronize multiple data streams, potentially from different sources, over a LAN network with millisecond accuracy (given configuration).
 
-For example, a VR display device running a Unity simulation may, using the [LSL4Unity](https://github.com/xfleckx/LSL4Unity) library, emit string markers into LSL corresponding to events of interest (For the P300 ERP, this event would be the onset of an attended, unusual noise in a pattern of commonplace ones). The computer doing data collection via the OpenBCI_NodeJS library (potentially with 4ms accuracy) would then output into an LSL stream the EEG and AUX data. LSL can then synchronize the two clocks relative to each other before inputting into a different program or toolkit, like [BCILAB](https://github.com/sccn/BCILAB) for analysis to trigger responses in the Unity display.
+For a demonstration of how to use LSL with the OpenBCI NodeJS SDK, go to our [labstreaminglayer example](https://github.com/OpenBCI/OpenBCI_NodeJS/tree/master/examples/labstreaminglayer), which contains code that is ready to start an LSL stream of OpenBCI data.
 
-This requires OpenBCI_NodeJS exporting data into LSL. Currently, there does not exist a pre-built NodeJS module for LSL, though LSL comes with tools that could possibly allow creation of one. In the meantime, the simpler route is to use a concurrent python script (driven by NodeJS module [python-shell](https://www.npmjs.com/package/python-shell)) to handoff the data to LSL for you, like so:
+To use this code, go to the directory and run:
 
-In your NodeJS code, before initializing/connecting to the OpenBCIBoard:
-```js
-// Construct LSL Handoff Python Shell
-var PythonShell = require('python-shell');
-var lsloutlet = new PythonShell('LslHandoff.py');
-
-lsloutlet.on('message', function(message){
-    console.log('LslOutlet: ' + message);
-});
-console.log('Python Shell Created for LSLHandoff');
+```
+npm install
 ```
 
-In your NodeJS code, when reading samples:
-```js
-st = sample.channelData.join(' ')
-//getTime returns milliseconds since midnight 1970/01/01
-var s = ''+ sample.timeStamp + ': '+ st
-lsloutlet.send(s)
+To start streaming, run:
+```
+npm start
 ```
 
-in LSLHandoff.py:
-```py
-from pylsl import StreamInfo, StreamOutlet
-info = StreamInfo('OpenBCI_EEG', 'EEG', 8, 250, 'float32', '[RANDOM NUMBER HERE]')
-outlet = StreamOutlet(info)
-while True:
-    strSample = raw_input().split(': ',1)
-    sample = map(float, strSample[1].split(' '))
-    stamp = float(strSample[0])
+Depending on your computer settings, you may need to run this code with `sudo` or root privileges.
 
-    outlet.push_sample(sample, stamp)
-    print('Pushed Sample At: ' + strSample[0])
-```
-AUX data would be done the same way in a separate LSL stream.
+For further information on customizing and incorporating LSL in your own OpenBCI NodeJS program, see the [readme](https://github.com/OpenBCI/OpenBCI_NodeJS/tree/master/examples/python).
+
 
 ## <a name="developing"></a> Developing:
 ### <a name="developing-running"></a> Running:

--- a/README.md
+++ b/README.md
@@ -1156,24 +1156,11 @@ The name of the simulator port.
 
 ### <a name="interfacing-with-other-tools-labstreaminglayer"></a> LabStreamingLayer
 
-[LabStreamingLayer](https://github.com/sccn/labstreaminglayer) by SCCN is a stream management tool designed to time-synchronize multiple data streams, potentially from different sources, over a LAN network with millisecond accuracy (given configuration).
+[LabStreamingLayer](https://github.com/sccn/labstreaminglayer) is a tool for streaming or recording time-series data. It can be used to interface with [Matlab](https://github.com/sccn/labstreaminglayer/tree/master/LSL/liblsl-Matlab), [Python](https://github.com/sccn/labstreaminglayer/tree/master/LSL/liblsl-Python), [Unity](https://github.com/xfleckx/LSL4Unity), and many other programs. 
 
-For a demonstration of how to use LSL with the OpenBCI NodeJS SDK, go to our [labstreaminglayer example](https://github.com/OpenBCI/OpenBCI_NodeJS/tree/master/examples/labstreaminglayer), which contains code that is ready to start an LSL stream of OpenBCI data.
+To use LSL with the NodeJS SDK, go to our [labstreaminglayer example](https://github.com/OpenBCI/OpenBCI_NodeJS/tree/master/examples/labstreaminglayer), which contains code that is ready to start an LSL stream of OpenBCI data.
 
-To use this code, go to the directory and run:
-
-```
-npm install
-```
-
-To start streaming, run:
-```
-npm start
-```
-
-Depending on your computer settings, you may need to run this code with `sudo` or root privileges.
-
-For further information on customizing and incorporating LSL in your own OpenBCI NodeJS program, see the [readme](https://github.com/OpenBCI/OpenBCI_NodeJS/tree/master/examples/python).
+Follow the directions in the [readme](https://github.com/OpenBCI/OpenBCI_NodeJS/blob/master/examples/labstreaminglayer/readme.md) to get started.
 
 
 ## <a name="developing"></a> Developing:

--- a/examples/labstreaminglayer/handoff.py
+++ b/examples/labstreaminglayer/handoff.py
@@ -1,0 +1,90 @@
+import json
+import sys
+import numpy as np
+import time
+import zmq
+from pylsl import StreamInfo, StreamOutlet
+
+class Interface:
+    def __init__(self, verbose=False):
+        context = zmq.Context()
+        self._socket = context.socket(zmq.PAIR)
+        self._socket.connect("tcp://localhost:3004")
+
+        self.verbose = verbose
+
+        if self.verbose:
+            print("Client Ready!")
+
+        # Send a quick message to tell node process we are up and running
+        self.send(json.dumps({
+            'action': 'started',
+            'command': 'status',
+            'message': time.time()*1000.0
+        }))
+
+    def send(self, msg):
+        """
+        Sends a message to TCP server
+        :param msg: str
+            A string to send to node TCP server, could be a JSON dumps...
+        :return: None
+        """
+        if self.verbose:
+            print('<- out ' + msg)
+        self._socket.send_string(msg)
+        return
+
+    def recv(self):
+        """
+        Checks the ZeroMQ for data
+        :return: str
+            String of data
+        """
+        return self._socket.recv()
+
+
+def initializeOutlet(interface):
+    """
+    Initializes and returns an LSL outlet
+    :param interface: Interface
+        the Python interface to communicate with node
+    :return: StreamOutlet
+        returns a labstreaminglayer StreamOutlet
+    """
+    numChans = None
+    while not numChans:
+        msg = interface.recv()
+        try:
+            dicty = json.loads(msg)
+            numChans = dicty.get('numChans')
+            sampleRate = dicty.get('sampleRate')
+        except ValueError as e:
+            print(e)
+    info = StreamInfo('OpenBCI_EEG', 'EEG', numChans, sampleRate, 'float32', 'myuid34234')
+    outlet = StreamOutlet(info)
+    print('init')
+    return outlet
+
+def main(argv):
+    verbose = False
+    # Create a new python interface.
+    interface = Interface(verbose)
+    # Create a new labstreaminglayer outlet
+    outlet = initializeOutlet(interface);
+
+    # Stream incoming data to LSL
+    while True:
+        msg = interface.recv()
+        try:
+            dicty = json.loads(msg)
+            message = dicty.get('message')
+            data=message.get('channelData')
+            timeStamp = message.get('timeStamp')
+            outlet.push_sample(data,timeStamp)
+        except BaseException as e:
+            print(e)
+
+
+if __name__ == '__main__':
+    main(sys.argv[1:])

--- a/examples/labstreaminglayer/index.js
+++ b/examples/labstreaminglayer/index.js
@@ -1,0 +1,160 @@
+/**
+ * This is an example from the readme.md
+ * On windows you should run with PowerShell not git bash.
+ * Install
+ *   [nodejs](https://nodejs.org/en/)
+ *
+ * To run:
+ *   change directory to this file `cd examples/debug`
+ *   do `npm install`
+ *   then `npm start`
+ */
+var OpenBCIBoard = require('openbci').OpenBCIBoard;
+var portPub = 'tcp://127.0.0.1:3004';
+var zmq = require('zmq-prebuilt');
+var socket = zmq.socket('pair');
+var debug = false; // Pretty print any bytes in and out... it's amazing...
+var verbose = true; // Adds verbosity to functions
+
+var ourBoard = new OpenBCIBoard({
+  // simulate: simulate, // Uncomment to see how it works with simulator!
+  simulatorFirmwareVersion: 'v2',
+  debug: debug,
+  verbose: verbose
+});
+
+var sampleRate = 250; // Default to 250, ALWAYS verify with a call to `.sampleRate()` after 'ready' event!
+var timeSyncPossible = false;
+var resyncPeriodMin = 1;
+var secondsInMinute = 60;
+var numChans = 8;
+var resyncPeriod = ourBoard.sampleRate() * resyncPeriodMin * secondsInMinute;
+
+ourBoard.autoFindOpenBCIBoard().then(portName => {
+  if (portName) {
+    /**
+     * Connect to the board with portName
+     * i.e. ourBoard.connect(portName).....
+     */
+    // Call to connect
+    ourBoard.connect(portName)
+      .then(() => {
+        ourBoard.on('ready', () => {
+          // Get the sample rate after 'ready'
+          sampleRate = ourBoard.sampleRate();
+          numChans = ourBoard.numberOfChannels();
+          if (numChans === 16) {
+            ourBoard.overrideInfoForBoardType('daisy');
+          }
+
+          // Find out if you can even time sync, you must be using v2 and this is only accurate after a `.softReset()` call which is called internally on `.connect()`. We parse the `.softReset()` response for the presence of firmware version 2 properties.
+          timeSyncPossible = ourBoard.usingVersionTwoFirmware();
+
+          sendToPython({'numChans': numChans, 'sampleRate': sampleRate});
+          if (timeSyncPossible) {
+            ourBoard.streamStart()
+              .catch(err => {
+                console.log(`stream start: ${err}`);
+              });
+          } else {
+            console.log('not able to time sync');
+          }
+        });
+      })
+      .catch(err => {
+        console.log(`connect: ${err}`);
+      });
+  } else {
+    /** Unable to auto find OpenBCI board */
+    console.log('Unable to auto find OpenBCI board');
+  }
+});
+
+var sampleFunc = sample => {
+  if (sample._count % resyncPeriod === 0) {
+    ourBoard.syncClocksFull()
+      .then(syncObj => {
+        // Sync was successful
+        if (syncObj.valid) {
+          // Log the object to check it out!
+          console.log(`timeOffset`, syncObj.timeOffsetMaster);
+        } else {
+          // Retry it
+          console.log(`Was not able to sync... retry!`);
+        }
+      });
+  }
+
+  if (sample.timeStamp) { // true after the first successful sync
+    if (sample.timeStamp < 10 * 60 * 60 * 1000) { // Less than 10 hours
+      console.log(`Bad time sync ${sample.timeStamp}`);
+    } else {
+      sendToPython({
+        action: 'process',
+        command: 'sample',
+        message: sample
+      });
+    }
+  }
+};
+
+// Subscribe to your functions
+ourBoard.on('sample', sampleFunc);
+
+// ZMQ
+socket.bind(portPub, function (err) {
+  if (err) throw err;
+  console.log(`bound to ${portPub}`);
+});
+
+/**
+ * Used to send a message to the Python process.
+ * @param  {Object} interProcessObject The standard inter-process object.
+ * @return {None}
+ */
+var sendToPython = (interProcessObject, verbose) => {
+  if (verbose) {
+    console.log(`<- out ${JSON.stringify(interProcessObject)}`);
+  }
+  if (socket) {
+    socket.send(JSON.stringify(interProcessObject));
+  }
+};
+
+function exitHandler (options, err) {
+  if (options.cleanup) {
+    if (verbose) console.log('clean');
+    /** Do additional clean up here */
+  }
+  if (err) console.log(err.stack);
+  if (options.exit) {
+    if (verbose) console.log('exit');
+    ourBoard.disconnect().catch(console.log);
+  }
+}
+
+if (process.platform === 'win32') {
+  const rl = require('readline').createInterface({
+    input: process.stdin,
+    output: process.stdout
+  });
+
+  rl.on('SIGINT', function () {
+    process.emit('SIGINT');
+  });
+}
+
+// do something when app is closing
+process.on('exit', exitHandler.bind(null, {
+  cleanup: true
+}));
+
+// catches ctrl+c event
+process.on('SIGINT', exitHandler.bind(null, {
+  exit: true
+}));
+
+// catches uncaught exceptions
+process.on('uncaughtException', exitHandler.bind(null, {
+  exit: true
+}));

--- a/examples/labstreaminglayer/package.json
+++ b/examples/labstreaminglayer/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "labstreaminglayer",
+  "version": "1.0.0",
+  "description": "labstreaminglayer example",
+  "main": "index.js",
+  "scripts": {
+    "start": "concurrently --kill-others \"python handoff.py\" \"node index.js\"",
+    "start-node": "node index.js",
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [
+    "python",
+    "openbci",
+    "node",
+    "labstreaminglayer",
+    "LSL"
+  ],
+  "author": "AJ Keller",
+  "license": "MIT",
+  "dependencies": {
+    "openbci": "^1.4.2",
+    "zmq-prebuilt": "^2.1.0"
+  },
+  "devEngines": {
+    "node": "<=6.x",
+    "npm": ">=3.x"
+  },
+  "devDependencies": {
+    "concurrently": "^3.1.0"
+  }
+}

--- a/examples/labstreaminglayer/readme.md
+++ b/examples/labstreaminglayer/readme.md
@@ -1,0 +1,42 @@
+# OpenBCI Node SDK to Python
+
+## About
+
+This code provides an example of how to stream OpenBCI data through the [lab streaming layer](https://github.com/sccn/labstreaminglayer) using the NodeJS SDK. The code is ready to run in order to start streaming right away, but can be modified and extended to customize how you are sending your data. This is designed to be used with the *OpenBCI Cyton* (for Ganglion support, see [here](https://github.com/OpenBCI/OpenBCI_NodeJS_Ganglion/tree/master/examples/labstreaminglayer)
+
+## Prerequisites
+
+* [Python](https://www.python.org/downloads/)
+* [ZeroMQ](http://zeromq.org/bindings:python)
+
+  ```py
+  pip install pyzmq
+  ```
+* [Node.js LTS](https://nodejs.org/en/)
+* [Lab Streaming Layer](https://github.com/sccn/labstreaminglayer)
+  ```py
+   pip install pylsl
+  ```
+
+
+## Installation
+For Python do:
+```bash
+python setup.py install
+```
+For Node:
+```bash
+npm install
+```
+
+## Running
+```
+npm start
+```
+For running just the node, for example if you were running the python in a separate ide and debugging, it's useful.
+```python
+npm run start-node
+```
+
+## Contributing
+Please PR if you have code to contribute!

--- a/examples/labstreaminglayer/readme.md
+++ b/examples/labstreaminglayer/readme.md
@@ -2,7 +2,9 @@
 
 ## About
 
-This code provides an example of how to stream OpenBCI data through the [lab streaming layer](https://github.com/sccn/labstreaminglayer) using the NodeJS SDK. The code is ready to run in order to start streaming right away, but can be modified and extended to customize how you are sending your data. This is designed to be used with the *OpenBCI Cyton* (for Ganglion support, see [here](https://github.com/OpenBCI/OpenBCI_NodeJS_Ganglion/tree/master/examples/labstreaminglayer)
+This code provides an example of how to stream OpenBCI data through the [lab streaming layer](https://github.com/sccn/labstreaminglayer) using the NodeJS SDK.
+
+Follow the steps in this README to start streaming. The code is ready to run as-is, but can be modified and extended to customize how you are sending your data. This is designed to be used with the ***OpenBCI Cyton*** (for Ganglion support, see [here](https://github.com/OpenBCI/OpenBCI_NodeJS_Ganglion/tree/master/examples/labstreaminglayer)
 
 ## Prerequisites
 
@@ -14,6 +16,7 @@ This code provides an example of how to stream OpenBCI data through the [lab str
   ```
 * [Node.js LTS](https://nodejs.org/en/)
 * [Lab Streaming Layer](https://github.com/sccn/labstreaminglayer)
+
   ```py
    pip install pylsl
   ```

--- a/examples/labstreaminglayer/readme.md
+++ b/examples/labstreaminglayer/readme.md
@@ -31,6 +31,7 @@ Next, install NodeJS dependencies:
 ```bash
 npm install
 ```
+Note: depending on your computer settings, you may need to run as administrator or with `sudo`.
 
 ## Running
 ```
@@ -40,6 +41,7 @@ For running just the node, for example if you were running the python in a separ
 ```python
 npm run start-node
 ```
+Note: depending on your computer settings, you may need to run as administrator or with `sudo`.
 
 ## Writing Lab Streaming Layer Code
 If you would like to use lab streaming layer in a custom OpenBCI NodeJS application, you must include an instance of the OpenBCI NodeJS library and an instance of a Python interface. A basic example is shown below:

--- a/examples/labstreaminglayer/readme.md
+++ b/examples/labstreaminglayer/readme.md
@@ -4,7 +4,7 @@
 
 This code provides an example of how to stream OpenBCI data through the [lab streaming layer](https://github.com/sccn/labstreaminglayer) using the NodeJS SDK.
 
-Follow the steps in this README to start streaming. The code is ready to run as-is, but can be modified and extended to customize how you are sending your data. This is designed to be used with the ***OpenBCI Cyton*** (for Ganglion support, see the [Ganglion Node SDK](https://github.com/OpenBCI/OpenBCI_NodeJS_Ganglion/tree/master/examples/labstreaminglayer)).
+Follow the steps in this README to start streaming. The code is ready to run as-is, but can be modified and extended to customize how you are sending your data. This is designed to be used with the **OpenBCI Cyton** (for **Ganglion support**, see the [Ganglion Node SDK](https://github.com/OpenBCI/OpenBCI_NodeJS_Ganglion/tree/master/examples/labstreaminglayer)).
 
 ## Prerequisites
 
@@ -23,11 +23,11 @@ Follow the steps in this README to start streaming. The code is ready to run as-
 
 
 ## Installation
-For Python do:
+First, install Python dependencies:
 ```bash
 python setup.py install
 ```
-For Node:
+Next, install NodeJS dependencies:
 ```bash
 npm install
 ```

--- a/examples/labstreaminglayer/readme.md
+++ b/examples/labstreaminglayer/readme.md
@@ -4,7 +4,7 @@
 
 This code provides an example of how to stream OpenBCI data through the [lab streaming layer](https://github.com/sccn/labstreaminglayer) using the NodeJS SDK.
 
-Follow the steps in this README to start streaming. The code is ready to run as-is, but can be modified and extended to customize how you are sending your data. This is designed to be used with the ***OpenBCI Cyton*** (for Ganglion support, see [here](https://github.com/OpenBCI/OpenBCI_NodeJS_Ganglion/tree/master/examples/labstreaminglayer)
+Follow the steps in this README to start streaming. The code is ready to run as-is, but can be modified and extended to customize how you are sending your data. This is designed to be used with the ***OpenBCI Cyton*** (for Ganglion support, see the [Ganglion Node SDK](https://github.com/OpenBCI/OpenBCI_NodeJS_Ganglion/tree/master/examples/labstreaminglayer)).
 
 ## Prerequisites
 

--- a/examples/labstreaminglayer/readme.md
+++ b/examples/labstreaminglayer/readme.md
@@ -41,5 +41,70 @@ For running just the node, for example if you were running the python in a separ
 npm run start-node
 ```
 
+## Writing Lab Streaming Layer Code
+If you would like to use lab streaming layer in a custom OpenBCI NodeJS application, you must include an instance of the OpenBCI NodeJS library and an instance of a Python interface. A basic example is shown below:
+
+`index.js`
+```js
+// Construct LSL Handoff Python Shell
+var OpenBCIBoard = require('openbci').OpenBCIBoard;
+var portPub = 'tcp://127.0.0.1:3004';
+var zmq = require('zmq-prebuilt');
+var socket = zmq.socket('pair');
+var ourBoard = new OpenBCIBoard();
+
+socket.bind(portPub);
+
+ourBoard.autoFindOpenBCIBoard().then(portName => {
+  if (portName) {
+    ourBoard.connect(portName) // Port name is a serial port name, see `.listPorts()`
+      .then(() => {
+        ourBoard.on('ready',() => {
+          ourBoard.streamStart();
+          ourBoard.on('sample',(sample) => {
+              if (socket) {
+                socket.send(JSON.stringify({message: sample}));
+              }
+            }
+          });
+        });
+      });
+  } else {
+    console.log('Unable to auto find OpenBCI board');
+  }
+});
+
+/* Insert additional exit handlers and cleanup below*/
+```
+
+`handoff.py`
+```python
+import json
+import zmq
+from pylsl import StreamInfo, StreamOutlet
+
+# Create ZMQ socket
+context = zmq.Context()
+_socket = context.socket(zmq.PAIR)
+_socket.connect("tcp://localhost:3004")
+
+# Create a new labstreaminglayer outlet
+numChans = 8;
+sampleRate = 250;
+info = StreamInfo('OpenBCI_EEG', 'EEG', numChans, sampleRate, 'float32', 'openbci_12345')
+outlet = StreamOutlet(info)
+# Stream incoming data to LSL
+while True:
+    msg = _socket.recv()
+    try:
+        dicty = json.loads(msg)
+        message = dicty.get('message')
+        data=message.get('channelData')
+        timeStamp = message.get('timeStamp')
+        outlet.push_sample(data,timeStamp)
+    except BaseException as e:
+        print(e)
+```
+
 ## Contributing
 Please PR if you have code to contribute!

--- a/examples/labstreaminglayer/readme.md
+++ b/examples/labstreaminglayer/readme.md
@@ -1,4 +1,4 @@
-# OpenBCI Node SDK to Python
+# OpenBCI Node SDK to Lab Streaming Layer
 
 ## About
 

--- a/examples/labstreaminglayer/readme.md
+++ b/examples/labstreaminglayer/readme.md
@@ -44,9 +44,8 @@ npm run start-node
 ## Writing Lab Streaming Layer Code
 If you would like to use lab streaming layer in a custom OpenBCI NodeJS application, you must include an instance of the OpenBCI NodeJS library and an instance of a Python interface. A basic example is shown below:
 
-`index.js`
+index.js
 ```js
-// Construct LSL Handoff Python Shell
 var OpenBCIBoard = require('openbci').OpenBCIBoard;
 var portPub = 'tcp://127.0.0.1:3004';
 var zmq = require('zmq-prebuilt');
@@ -77,7 +76,7 @@ ourBoard.autoFindOpenBCIBoard().then(portName => {
 /* Insert additional exit handlers and cleanup below*/
 ```
 
-`handoff.py`
+handoff.py
 ```python
 import json
 import zmq

--- a/examples/labstreaminglayer/setup.py
+++ b/examples/labstreaminglayer/setup.py
@@ -1,8 +1,8 @@
 from setuptools import setup, find_packages
 
-setup(name='openbci-node-python',
+setup(name='openbci-node-labstreaminglayer',
       version='0.0.1',
-      description='Node to Python the right way',
+      description='Labstreaminglayer with NodeJS',
       url='',
       author='AJ Keller',
       author_email='pushtheworldllc@gmail.com',

--- a/examples/labstreaminglayer/setup.py
+++ b/examples/labstreaminglayer/setup.py
@@ -1,0 +1,12 @@
+from setuptools import setup, find_packages
+
+setup(name='openbci-node-python',
+      version='0.0.1',
+      description='Node to Python the right way',
+      url='',
+      author='AJ Keller',
+      author_email='pushtheworldllc@gmail.com',
+      license='MIT',
+      packages=find_packages(),
+      install_requires=['numpy', 'pyzmq','pylsl'],
+      zip_safe=False)


### PR DESCRIPTION
I figured it would be good to add an example of working code for streaming through LSL using the NodeJS SDK . This uses a modified version of the NodeJS -> Python technique shown in the other example file. The code is ready to stream as-is, which should make this directory useful for people who would like to just start streaming on LSL right away.

Equivalent code for the ganglion is mostly written using the same technique (though I'm running into the roadblock in [this Ganglion issue](https://github.com/OpenBCI/OpenBCI_NodeJS_Ganglion/issues/23)!) If this looks good to you, I'll post a pull request there once it's done.