### PR TITLE
Fix typo in "timeStamp" word

### DIFF
--- a/openBCISample.js
+++ b/openBCISample.js
@@ -903,7 +903,7 @@ function makeDaisySampleObject (lowerSampleObject, upperSampleObject) {
     'upper': upperSampleObject.auxData
   };
 
-  daisySampleObject['timestamp'] = (lowerSampleObject.timestamp + upperSampleObject.timestamp) / 2;
+  daisySampleObject['timeStamp'] = (lowerSampleObject.timeStamp + upperSampleObject.timeStamp) / 2;
 
   daisySampleObject['_timestamps'] = {
     'lower': lowerSampleObject.timestamp,


### PR DESCRIPTION
This caused the timestamp never to reach the sample resolve function when reading data in daisy mode.