### PR TITLE
Fix for printing debug output

### DIFF
--- a/README.md
+++ b/README.md
@@ -1139,7 +1139,7 @@ ourBoard.write('o');
 
 Emitted when the serial connection to the board is closed.
 
-#### <a name="event-close"></a> .on('droppedPacket', callback)
+#### <a name="event-dropped-packet"></a> .on('droppedPacket', callback)
 
 Emitted when a packet (or packets) are dropped. Returns an array.
 
@@ -1171,7 +1171,7 @@ Emitted when the board is in a ready to start streaming state.
 
 Emitted when there is a new sample available.
 
-#### <a name="event-sample"></a> .on('synced', callback)
+#### <a name="event-synced"></a> .on('synced', callback)
 
 Emitted when there is a new sample available.
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,9 @@
+# 2.0.1
+
+### Bug Fixes
+
+* Debug bytes was set to always print in processBytes
+
 # 2.0.0
 
 ### New Features

--- a/openBCICyton.js
+++ b/openBCICyton.js
@@ -553,7 +553,7 @@ Cyton.prototype.write = function (dataToWrite) {
  * @author AJ Keller (@pushtheworldllc)
  */
 Cyton.prototype._writeAndDrain = function (data) {
-  obciDebug.debugBytes('>>>', data);
+  if (this.options.debug) obciDebug.debugBytes('>>>', data);
 
   return new Promise((resolve, reject) => {
     if (!this.isConnected()) return reject(Error('Serial port not open'));
@@ -1772,7 +1772,7 @@ Cyton.prototype.syncClocksFull = function () {
  * @author AJ Keller (@pushtheworldllc)
  */
 Cyton.prototype._processBytes = function (data) {
-  obciDebug.debugBytes(this.curParsingMode + '<<', data);
+  if (this.options.debug) obciDebug.debugBytes(this.curParsingMode + '<<', data);
 
   // Concat old buffer
   var oldDataBuffer = null;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "The official Node.js SDK for the OpenBCI Biosensor Board.",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
# 2.0.1

### Bug Fixes

* Debug bytes was set to always print in processBytes