### PR TITLE
Working on stabalizing daisy

### DIFF
--- a/README.md
+++ b/README.md
@@ -1143,6 +1143,10 @@ Emitted when the serial connection to the board is closed.
 
 Emitted when a packet (or packets) are dropped. Returns an array.
 
+#### <a name="event-eot"></a> .on('eot', callback)
+
+Emitted when there is an EOT a.k.a. '$$$' with a buffer filled with the data.
+
 #### <a name="event-error"></a> .on('error', callback)
 
 Emitted when there is an on the serial port.

--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,13 @@
+# 2.1.0
+
+### Breaking changes
+
+* Significantly reduce the properties in `this.info` object to only have firmware version and number of missed packets. Code dependent on this.info should switch to using `numberOfChannels()`, and `getBoardType()` and `sampleRate()` for accurate board info!
+
+### Enhancements
+
+* Fixes for daisy with new board, specifically hardSet.
+
 # 2.0.1
 
 ### Bug Fixes

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci",
-  "version": "2.0.1",
+  "version": "2.1.0",
   "description": "The official Node.js SDK for the OpenBCI Biosensor Board.",
   "main": "index.js",
   "scripts": {
@@ -21,7 +21,7 @@
     "gaussian": "^1.0.0",
     "lodash": "^4.17.4",
     "mathjs": "^3.14.2",
-    "openbci-utilities": "0.0.9",
+    "openbci-utilities": "0.0.10",
     "performance-now": "^2.1.0",
     "safe-buffer": "^5.1.1",
     "serialport": "4.0.7",

--- a/test/openBCICyton-test.js
+++ b/test/openBCICyton-test.js
@@ -71,7 +71,7 @@ describe('openbci-sdk', function () {
     });
     it('constructs with the correct default options', () => {
       var board = new Cyton();
-      expect(board.options.boardType).to.equal(k.OBCIBoardDefault);
+      expect(board.options.boardType).to.equal(k.OBCIBoardCyton);
       expect(board.options.baudRate).to.equal(115200);
       expect(board.options.hardSet).to.be.false();
       expect(board.options.sendCounts).to.be.false();
@@ -467,32 +467,70 @@ describe('openbci-sdk', function () {
           });
         }).catch(err => done(err));
     });
-    it('should be able to set info for default board', function () {
-      ourBoard.info.boardType = 'burrito';
-      ourBoard.info.sampleRate = 60;
-      ourBoard.info.numberOfChannels = 200;
-      ourBoard.overrideInfoForBoardType('default');
-      expect(ourBoard.getInfo().boardType).to.be.equal(k.OBCIBoardDefault);
-      expect(ourBoard.getInfo().numberOfChannels).to.be.equal(k.OBCINumberOfChannelsDefault);
-      expect(ourBoard.getInfo().sampleRate).to.be.equal(k.OBCISampleRate250);
+    it('should be able to set info for cyton board', function (done) {
+      ourBoard.simulatorDisable()
+        .then(() => {
+          ourBoard.overrideInfoForBoardType('cyton');
+          expect(ourBoard.getBoardType()).to.be.equal(k.OBCIBoardCyton);
+          expect(ourBoard.numberOfChannels()).to.be.equal(k.OBCINumberOfChannelsCyton);
+          expect(ourBoard.sampleRate()).to.be.equal(k.OBCISampleRate250);
+          done();
+        })
+        .catch((err) => {
+          if (err.message === 'Not simulating') {
+            ourBoard.overrideInfoForBoardType('cyton');
+            expect(ourBoard.getBoardType()).to.be.equal(k.OBCIBoardCyton);
+            expect(ourBoard.numberOfChannels()).to.be.equal(k.OBCINumberOfChannelsCyton);
+            expect(ourBoard.sampleRate()).to.be.equal(k.OBCISampleRate250);
+            done();
+          } else {
+            done(err);
+          }
+        });
+
     });
-    it('should be able to set info for daisy board', function () {
-      ourBoard.info.boardType = 'burrito';
-      ourBoard.info.sampleRate = 60;
-      ourBoard.info.numberOfChannels = 200;
-      ourBoard.overrideInfoForBoardType('daisy');
-      expect(ourBoard.getInfo().boardType).to.be.equal(k.OBCIBoardDaisy);
-      expect(ourBoard.getInfo().numberOfChannels).to.be.equal(k.OBCINumberOfChannelsDaisy);
-      expect(ourBoard.getInfo().sampleRate).to.be.equal(k.OBCISampleRate125);
+    it('should be able to set info for daisy board', function (done) {
+      ourBoard.simulatorDisable()
+        .then(() => {
+          ourBoard.overrideInfoForBoardType('daisy');
+          expect(ourBoard.getBoardType()).to.be.equal(k.OBCIBoardDaisy);
+          expect(ourBoard.numberOfChannels()).to.be.equal(k.OBCINumberOfChannelsDaisy);
+          expect(ourBoard.sampleRate()).to.be.equal(k.OBCISampleRate125);
+          done();
+        })
+        .catch((err) => {
+          if (err.message === 'Not simulating') {
+            ourBoard.overrideInfoForBoardType('daisy');
+            expect(ourBoard.getBoardType()).to.be.equal(k.OBCIBoardDaisy);
+            expect(ourBoard.numberOfChannels()).to.be.equal(k.OBCINumberOfChannelsDaisy);
+            expect(ourBoard.sampleRate()).to.be.equal(k.OBCISampleRate125);
+            done();
+          } else {
+            done(err);
+          }
+        });
     });
-    it('should set info to default on bad input string', function () {
-      ourBoard.info.boardType = 'burrito';
-      ourBoard.info.sampleRate = 60;
-      ourBoard.info.numberOfChannels = 200;
-      ourBoard.overrideInfoForBoardType('taco');
-      expect(ourBoard.getInfo().boardType).to.be.equal(k.OBCIBoardDefault);
-      expect(ourBoard.getInfo().numberOfChannels).to.be.equal(k.OBCINumberOfChannelsDefault);
-      expect(ourBoard.getInfo().sampleRate).to.be.equal(k.OBCISampleRate250);
+    it('should set info to default on bad input string', function (done) {
+      ourBoard.simulatorDisable()
+        .then(() => {
+          ourBoard.overrideInfoForBoardType('taco');
+          expect(ourBoard.getBoardType()).to.be.equal(k.OBCIBoardCyton);
+          expect(ourBoard.numberOfChannels()).to.be.equal(k.OBCINumberOfChannelsCyton);
+          expect(ourBoard.sampleRate()).to.be.equal(k.OBCISampleRate250);
+          done();
+        })
+        .catch((err) => {
+          if (err.message === 'Not simulating') {
+            ourBoard.overrideInfoForBoardType('cyton');
+            expect(ourBoard.getBoardType()).to.be.equal(k.OBCIBoardCyton);
+            expect(ourBoard.numberOfChannels()).to.be.equal(k.OBCINumberOfChannelsCyton);
+            expect(ourBoard.sampleRate()).to.be.equal(k.OBCISampleRate250);
+            done();
+          } else {
+            done(err);
+          }
+        });
+
     });
   });
   describe('#debug', function () {
@@ -639,7 +677,7 @@ describe('openbci-sdk', function () {
           };
           const hardSetFuncOnTime = () => {
             // Verify the module is still default
-            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDefault);
+            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardCyton);
             // Remove the premature ready function because it won't fire
             ourBoard.removeListener('ready', readyFuncPreMature);
             // If the board was able to attach the daisy
@@ -695,7 +733,7 @@ describe('openbci-sdk', function () {
           };
           const hardSetFuncOnTime = () => {
             // Verify the module is still default
-            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDefault);
+            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardCyton);
             // Remove the premature ready function because it won't fire
             ourBoard.removeListener('ready', readyFuncPreMature);
             // If the board was able to attach the daisy
@@ -705,7 +743,7 @@ describe('openbci-sdk', function () {
           };
           const errorFuncTestSuccess = () => {
             // Verify the module is still default
-            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDefault);
+            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardCyton);
             ourBoard.options.hardSet = false;
             ourBoard.disconnect().then(() => { // call disconnect
               ourBoard.removeListener('ready', readyFuncTestFailure);
@@ -735,7 +773,7 @@ describe('openbci-sdk', function () {
           // Turn hardSet on
           ourBoard.options.hardSet = true;
           // Set the options to daisy boardType
-          ourBoard.options.boardType = k.OBCIBoardDefault;
+          ourBoard.options.boardType = k.OBCIBoardCyton;
           // The simulator has a daisy attached
           ourBoard.options.simulatorDaisyModuleAttached = true;
 
@@ -767,7 +805,7 @@ describe('openbci-sdk', function () {
           };
           const readyFuncSuccess = () => {
             // Verify the module switched to default type
-            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDefault);
+            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardCyton);
             // Remove because it won't fire
             ourBoard.removeListener('error', errorFuncTestFailure);
             ourBoard.options.hardSet = false;
@@ -839,7 +877,7 @@ describe('openbci-sdk', function () {
           // Turn hardSet on
           ourBoard.options.hardSet = true;
           // Set the options to default boardType
-          ourBoard.options.boardType = k.OBCIBoardDefault;
+          ourBoard.options.boardType = k.OBCIBoardCyton;
           // The simulator does not have a daisy
           ourBoard.options.simulatorDaisyModuleAttached = false;
           // The simulator is able to attach daisy
@@ -866,7 +904,7 @@ describe('openbci-sdk', function () {
             ourBoard.removeListener('error', errorFuncTestFailure);
             ourBoard.removeListener('hardSet', hardSetFuncFailure);
             // Verify the module is still default
-            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDefault);
+            expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardCyton);
             ourBoard.options.hardSet = false;
             ourBoard.disconnect().then(() => { // call disconnect
               done();
@@ -1142,7 +1180,7 @@ describe('openbci-sdk', function () {
           ourBoard.hardSetBoardType('default')
             .then((res) => {
               expect(res).to.equal('no daisy to remove');
-              expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDefault);
+              expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardCyton);
               done();
             }).catch(done);
         } else {
@@ -1155,7 +1193,7 @@ describe('openbci-sdk', function () {
           ourBoard.hardSetBoardType('default')
             .then((res) => {
               expect(res).to.equal('daisy removed');
-              expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDefault);
+              expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardCyton);
               done();
             }).catch(done);
         } else {
@@ -1197,7 +1235,7 @@ describe('openbci-sdk', function () {
             .then(done)
             .catch((err) => {
               expect(err.message).to.equal('unable to attach daisy');
-              expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDefault);
+              expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardCyton);
               done();
             });
         } else {
@@ -1980,9 +2018,9 @@ LIS3DH Device ID: 0x38422$$$`);
       ourBoard._processParseBufferForReset(buf);
 
       ourBoard.info.firmware.should.equal(k.OBCIFirmwareV1);
-      ourBoard.info.boardType.should.equal(k.OBCIBoardDefault);
-      ourBoard.info.sampleRate.should.equal(k.OBCISampleRate250);
-      ourBoard.info.numberOfChannels.should.equal(k.OBCINumberOfChannelsDefault);
+      expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardCyton);
+      expect(ourBoard.sampleRate()).to.equal(k.OBCISampleRate250);
+      expect(ourBoard.numberOfChannels()).to.equal(k.OBCINumberOfChannelsCyton);
     });
     it('should recognize firmware version 1 with daisy', () => {
       var buf = new Buffer(`OpenBCI V3 Simulator
@@ -1994,9 +2032,9 @@ $$$`);
       ourBoard._processParseBufferForReset(buf);
 
       ourBoard.info.firmware.should.equal(k.OBCIFirmwareV1);
-      ourBoard.info.boardType.should.equal(k.OBCIBoardDaisy);
-      ourBoard.info.sampleRate.should.equal(k.OBCISampleRate125);
-      ourBoard.info.numberOfChannels.should.equal(k.OBCINumberOfChannelsDaisy);
+      expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDaisy);
+      expect(ourBoard.sampleRate()).to.equal(k.OBCISampleRate125);
+      expect(ourBoard.numberOfChannels()).to.equal(k.OBCINumberOfChannelsDaisy);
     });
     it('should recognize firmware version 2 with no daisy', () => {
       var buf = new Buffer(`OpenBCI V3 Simulator
@@ -2008,9 +2046,9 @@ $$$`);
       ourBoard._processParseBufferForReset(buf);
 
       ourBoard.info.firmware.should.equal(k.OBCIFirmwareV2);
-      ourBoard.info.boardType.should.equal(k.OBCIBoardDefault);
-      ourBoard.info.sampleRate.should.equal(k.OBCISampleRate250);
-      ourBoard.info.numberOfChannels.should.equal(k.OBCINumberOfChannelsDefault);
+      expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardCyton);
+      expect(ourBoard.sampleRate()).to.equal(k.OBCISampleRate250);
+      expect(ourBoard.numberOfChannels()).to.equal(k.OBCINumberOfChannelsCyton);
     });
     it('should recognize firmware version 2 with daisy', () => {
       var buf = new Buffer(`OpenBCI V3 Simulator
@@ -2023,9 +2061,9 @@ $$$`);
       ourBoard._processParseBufferForReset(buf);
 
       ourBoard.info.firmware.should.equal(k.OBCIFirmwareV2);
-      ourBoard.info.boardType.should.equal(k.OBCIBoardDaisy);
-      ourBoard.info.sampleRate.should.equal(k.OBCISampleRate125);
-      ourBoard.info.numberOfChannels.should.equal(k.OBCINumberOfChannelsDaisy);
+      expect(ourBoard.getBoardType()).to.equal(k.OBCIBoardDaisy);
+      expect(ourBoard.sampleRate()).to.equal(k.OBCISampleRate125);
+      expect(ourBoard.numberOfChannels()).to.equal(k.OBCINumberOfChannelsDaisy);
     });
   });
 
@@ -2352,7 +2390,7 @@ $$$`);
       ourBoard = new Cyton({
         verbose: true
       });
-      randomSampleGenerator = openBCIUtilities.randomSample(k.OBCINumberOfChannelsDefault, k.OBCISampleRate250, false, 'none');
+      randomSampleGenerator = openBCIUtilities.randomSample(k.OBCINumberOfChannelsCyton, k.OBCISampleRate250, false, 'none');
     });
     beforeEach(() => {
       // Clear the global var

--- a/test/openBCICyton-test.js
+++ b/test/openBCICyton-test.js
@@ -487,7 +487,6 @@ describe('openbci-sdk', function () {
             done(err);
           }
         });
-
     });
     it('should be able to set info for daisy board', function (done) {
       ourBoard.simulatorDisable()
@@ -530,7 +529,6 @@ describe('openbci-sdk', function () {
             done(err);
           }
         });
-
     });
   });
   describe('#debug', function () {


### PR DESCRIPTION
# 2.1.0

### Breaking changes

* Significantly reduce the properties in `this.info` object to only have firmware version and number of missed packets. Code dependent on this.info should switch to using `numberOfChannels()`, and `getBoardType()` and `sampleRate()` for accurate board info!
