### PR TITLE
FIX: Sending channel setting commands might not work

### DIFF
--- a/changelog.md
+++ b/changelog.md
@@ -1,3 +1,11 @@
+# 2.2.0
+
+### Bug Fixes
+
+* Calling sdStart and stop would change the writeOutDelay
+* Timeout for v1 was set to 10 ms instead of 50 ms.
+* Timeout for v2+ was set to 0 ms instead of 10 ms.
+
 # 2.1.4
 
 ### Enhancements

--- a/examples/getStreaming/getStreaming.js
+++ b/examples/getStreaming/getStreaming.js
@@ -28,7 +28,19 @@ ourBoard.autoFindOpenBCIBoard().then(portName => {
     ourBoard.connect(portName) // Port name is a serial port name, see `.listPorts()`
       .then(() => {
         ourBoard.on('ready', () => {
-          ourBoard.streamStart();
+          ourBoard.syncRegisterSettings()
+            .then((cs) => {
+              return ourBoard.streamStart();
+            })
+            .catch((err) => {
+              console.log('err', err);
+              return ourBoard.streamStart();
+            })
+            .catch((err) => {
+              console.log('fatal err', err);
+              process.exit(0);
+            });
+
           ourBoard.on('sample', (sample) => {
             /** Work with sample */
             for (let i = 0; i < ourBoard.numberOfChannels(); i++) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openbci",
-  "version": "2.1.4",
+  "version": "2.2.0",
   "description": "The official Node.js SDK for the OpenBCI Biosensor Board.",
   "main": "index.js",
   "scripts": {

--- a/test/openBCICyton-test.js
+++ b/test/openBCICyton-test.js
@@ -553,7 +553,7 @@ describe('openbci-sdk', function () {
       setTimeout(() => {
         console.log.should.have.been.calledWithMatch(k.OBCIStreamStop);
         done();
-      }, 20);
+      }, k.OBCIWriteIntervalDelayMSLong * 2);
     });
     it('outputs a packet when received', done => {
       console.log.reset();


### PR DESCRIPTION
# 2.2.0

### Bug Fixes

* Calling sdStart and stop would change the writeOutDelay
* Timeout for v1 was set to 10 ms instead of 50 ms.
* Timeout for v2+ was set to 0 ms instead of 10 ms.